### PR TITLE
fix(ci): support macos arm64 arch

### DIFF
--- a/Mirage/Mirage Wallpaper/Services/RendererController.swift
+++ b/Mirage/Mirage Wallpaper/Services/RendererController.swift
@@ -112,9 +112,13 @@ final class RendererController {
         return machine
     }
 
-    /// CMake preset naming convention: `macos-{arch}-clang-{config}`.
+    /// CMake preset naming convention:
+    ///   Intel:    `macos-clang-{config}` (no arch suffix)
+    ///   Silicon:  `macos-arm64-clang-{config}`
     private static func sceneRendererPreset(config: String = "release") -> String {
-        "macos-\(hostArch)-clang-\(config)"
+        hostArch == "arm64"
+            ? "macos-arm64-clang-\(config)"
+            : "macos-clang-\(config)"
     }
 
     /// Homebrew prefix paths, ordered by current architecture preference.

--- a/scripts/preset.sh
+++ b/scripts/preset.sh
@@ -17,5 +17,11 @@ scene_preset() {
     local config="${1:-release}"
     local arch
     arch="$(uname -m)"
-    echo "macos-${arch}-clang-${config}"
+    # Intel preset names omit the architecture suffix (macos-clang-*),
+    # while Apple Silicon presets include -arm64 (macos-arm64-clang-*).
+    if [[ "$arch" == "arm64" ]]; then
+        echo "macos-arm64-clang-${config}"
+    else
+        echo "macos-clang-${config}"
+    fi
 }


### PR DESCRIPTION
## Summary

Fix GitHub Actions CI failure: `SceneRenderer/scripts/build.sh` generates wrong CMake preset name on Intel Macs, causing build to fail immediately.

## Root Cause

The `scene_preset()` function in `scripts/preset.sh` (introduced in `f8d1d94`) unconditionally concatenates `macos-${arch}-clang-${config}` where `${arch}` comes from `uname -m`.

On Intel Macs (`macos-15-intel` runner), `uname -m` returns `x86_64`, generating `macos-x86_64-clang-release`. However, `SceneRenderer/CMakePresets.json` defines Intel presets **without** an architecture suffix (`macos-clang-release` / `macos-clang-debug`). Only Apple Silicon presets include `-arm64`.

This naming convention was correct in the original `82c684f` commit (manual `if arm64` check) but was broken during the refactoring in `f8d1d94` / `854f39c` that introduced the shared `preset.sh`.

### Error

```
ERROR: unknown preset: macos-x86_64-clang-release
(expected macos-clang-release, macos-clang-debug, macos-arm64-clang-release, or macos-arm64-clang-debug)
```

## Changes

### `scripts/preset.sh`

Restore architecture-aware preset naming: arm64 gets `macos-arm64-clang-*`, all other architectures (including `x86_64`) get `macos-clang-*`.

### `Mirage/Mirage Wallpaper/Services/RendererController.swift`

Apply the same fix to `sceneRendererPreset()`, which is used for dev-time fallback binary resolution. While this doesn't directly affect CI (the bundled binary is used in production), it keeps the naming consistent with `CMakePresets.json` during local development.

## Verification

| Runner | `uname -m` | `scene_preset release` → | CMakePresets.json |
|--------|-----------|--------------------------|-------------------|
| `macos-15-intel` | `x86_64` | `macos-clang-release` | ✅ Matches |
| `macos-15` | `arm64` | `macos-arm64-clang-release` | ✅ Matches |

## Files Changed

- `scripts/preset.sh` — fix `scene_preset()` to handle Intel vs Apple Silicon correctly
- `Mirage/Mirage Wallpaper/Services/RendererController.swift` — fix `sceneRendererPreset()` for dev fallback paths

## Note

WebRenderer and VideoRenderer are unaffected — their CMake presets use simple `release`/`debug` names without architecture prefixes.
