### PR TITLE
Fix fps slider thumb jitter in PerformancePage by keeping status icon…

### DIFF
--- a/Mirage/Mirage Wallpaper/SettingsView/PerformancePage.swift
+++ b/Mirage/Mirage Wallpaper/SettingsView/PerformancePage.swift
@@ -134,6 +134,8 @@ struct PerformancePage: SettingsPage {
                     } else if viewModel.settings.fps > 30 {
                         Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.yellow)
                             .help("较高的帧率会增加耗电。")
+                    } else {
+                        Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
                     }
                 }
 


### PR DESCRIPTION
### 问题类型
界面、设置或系统集成

### 运行环境
Mirage: 版本 1.0.7（构建 308，提交 a85684cb8790）
macOS: macOS 26.5 (25F71)
Model: MacPro 2019 (Hackintosh)

### 问题描述
在设置界面的性能设置中，拖动帧率滑块经过 30 FPS 阈值时，由于 `HStack` 内条件插入/移除警告图标（`exclamationmark.triangle.fill`），导致 `Slider` 的占据空间左移，thumb 发生异常抽动。

复现视频：

https://github.com/user-attachments/assets/f703520c-8e76-4280-96d8-b7768a1a80e5

### 根因
原实现使用 `if / else if` 条件渲染图标：
- 当 `fps > 30` 时图标插入，`HStack` 重新分配空间，`Slider` 向左移动
- 当 `fps <= 30` 时图标移除，`Slider` 向右移动
- 手指仍在拖拽过程中，但 thumb 在视觉上参考的仍是旧布局宽度，导致视觉跳动

### 修复方案
将条件渲染改为**常驻图标**，通过切换 symbol 和颜色来表达状态，而非插入/移除视图：

- `fps > 60`：`exclamationmark.triangle.fill`（红色）
- `fps > 30`：`exclamationmark.triangle.fill`（黄色）
- `fps <= 30`：`checkmark.circle.fill`（绿色，**新增**）

这样图标占位宽度始终保持一致，彻底消除布局抖动。

### 改动范围
仅修改 `Mirage/MirageWallpaper/SettingsView/PerformancePage.swift` 中的帧率滑块行，未涉及渲染器、Steam 服务或业务逻辑。

### 测试验证
- [x] 拖动滑块跨越 30 FPS 阈值，thumb 不再跳动
- [x] 图标颜色与 symbol 正确切换（红 / 黄 / 绿）