### PR TITLE
fix(app): restore wallpapers on all displays at launch

### DIFF
--- a/Mirage/Mirage Wallpaper/AppDelegate.swift
+++ b/Mirage/Mirage Wallpaper/AppDelegate.swift
@@ -98,8 +98,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         SteamServiceManager.shared.start()
 
-        let w = wallpaperViewModel.currentWallpaper
-        if w.isValid {
+        // Gate on any persisted assignment, not the selected display's: the
+        // selected display may have had its wallpaper stopped while other
+        // displays still hold assignments that must come back after relaunch.
+        if wallpaperViewModel.hasAnyWallpaper {
             wallpaperViewModel.restoreAllDisplays()
         }
 

--- a/Mirage/Mirage Wallpaper/AppDelegate.swift
+++ b/Mirage/Mirage Wallpaper/AppDelegate.swift
@@ -98,9 +98,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         SteamServiceManager.shared.start()
 
-        // Gate on any persisted assignment, not the selected display's: the
-        // selected display may have had its wallpaper stopped while other
-        // displays still hold assignments that must come back after relaunch.
         if wallpaperViewModel.hasAnyWallpaper {
             wallpaperViewModel.restoreAllDisplays()
         }


### PR DESCRIPTION
## 问题 / Problem

`applicationDidFinishLaunching` 里的启动恢复逻辑以**当前选中显示器**的壁纸是否有效作为开关：

```swift
let w = wallpaperViewModel.currentWallpaper   // 只取 selectedDisplayKey 的壁纸
if w.isValid {
    wallpaperViewModel.restoreAllDisplays()
}
```

`currentWallpaper` 只反映 `selectedDisplayKey` 一块屏的状态。多显示器场景下，只要选中的那块屏没有壁纸，**其他显示器已持久化的壁纸也会被整体跳过恢复**。

## 复现步骤 / Repro

1. 双显示器，给显示器 A 设置壁纸；
2. 在 UI 中选中显示器 B，对 B 执行"停止壁纸"（此时 `selectedDisplayKey = B`，且该选择会持久化到 UserDefaults）；
3. 退出并重启 Mirage；
4. 预期：显示器 A 的壁纸自动恢复；实际：A 不恢复，但 UI 中 A 仍显示为已分配（`displayStates` 里的持久化条目还在）。

## 修复 / Fix

改用已有的 `hasAnyWallpaper`（任意显示器有持久化分配即恢复）作为门控。`restoreAllDisplays()` 本身就会逐个遍历已连接显示器、跳过没有分配或播放策略为停止的屏，所以这里只需要一个"有没有任何分配"的开关，而不是"选中屏是否有效"。

顺带说明：之所以此前不容易察觉，是启动时若恰好触发一次 `didChangeScreenParametersNotification`，`displayTopologyChanged` 会顺带补渲染掩盖这个问题——但这依赖系统行为，并不可靠。

https://claude.ai/code/session_01KzvPMuGxGW1jkwXkPRpAGi
