### PR TITLE
fix(web): correct vDSP real DFT input packing in audio spectrum

### DIFF
--- a/WebRenderer/Sources/WebRenderer/WRAudioTap.mm
+++ b/WebRenderer/Sources/WebRenderer/WRAudioTap.mm
@@ -319,11 +319,8 @@ static OSStatus WRTapIOProc(AudioDeviceID inDevice, const AudioTimeStamp *inNow,
 
     vDSP_vmul(window, 1, _hann, 1, window, 1, kFFT_N);
 
-    // vDSP's real-to-complex DFT expects the time samples split even/odd
-    // across Ir/Ii (kFFT_N/2 each), not the contiguous window. Feeding the
-    // window directly as Ir transforms a different signal: only the first
-    // half of the samples are read and every frequency lands at half its
-    // true bin.
+    // vDSP real DFT expects even/odd split, not contiguous input.
+    // Passing it directly uses only half the samples and halves the bin.
     float splitEven[kFFT_N / 2];
     float splitOdd[kFFT_N / 2];
     float realOut[kFFT_N / 2];
@@ -348,8 +345,7 @@ static OSStatus WRTapIOProc(AudioDeviceID inDevice, const AudioTimeStamp *inNow,
         grouped[b] = sumMag / (float)perGroup;
     }
 
-    // vDSP's real DFT is scaled 2x relative to the mathematical DFT, so the
-    // usual 2/N amplitude normalization becomes 1/half here.
+    // vDSP real DFT is 2x the mathematical DFT, so 2/N becomes 1/half here.
     const float norm = 1.0f / (float)half;
     const float logBase = 4.0f;
     for (NSUInteger b = 0; b < kBinCount; ++b) {

--- a/WebRenderer/Sources/WebRenderer/WRAudioTap.mm
+++ b/WebRenderer/Sources/WebRenderer/WRAudioTap.mm
@@ -319,10 +319,18 @@ static OSStatus WRTapIOProc(AudioDeviceID inDevice, const AudioTimeStamp *inNow,
 
     vDSP_vmul(window, 1, _hann, 1, window, 1, kFFT_N);
 
-    float realOut[kFFT_N];
-    float imagOut[kFFT_N];
-    static float zeroIn[kFFT_N];
-    vDSP_DFT_Execute(_dftSetup, window, zeroIn, realOut, imagOut);
+    // vDSP's real-to-complex DFT expects the time samples split even/odd
+    // across Ir/Ii (kFFT_N/2 each), not the contiguous window. Feeding the
+    // window directly as Ir transforms a different signal: only the first
+    // half of the samples are read and every frequency lands at half its
+    // true bin.
+    float splitEven[kFFT_N / 2];
+    float splitOdd[kFFT_N / 2];
+    float realOut[kFFT_N / 2];
+    float imagOut[kFFT_N / 2];
+    DSPSplitComplex packed = { .realp = splitEven, .imagp = splitOdd };
+    vDSP_ctoz((const DSPComplex *)window, 2, &packed, 1, kFFT_N / 2);
+    vDSP_DFT_Execute(_dftSetup, splitEven, splitOdd, realOut, imagOut);
 
     const NSUInteger half = kFFT_N / 2;
     const NSUInteger usableBins = half - 1;
@@ -340,7 +348,9 @@ static OSStatus WRTapIOProc(AudioDeviceID inDevice, const AudioTimeStamp *inNow,
         grouped[b] = sumMag / (float)perGroup;
     }
 
-    const float norm = 2.0f / (float)half;
+    // vDSP's real DFT is scaled 2x relative to the mathematical DFT, so the
+    // usual 2/N amplitude normalization becomes 1/half here.
+    const float norm = 1.0f / (float)half;
     const float logBase = 4.0f;
     for (NSUInteger b = 0; b < kBinCount; ++b) {
         float m = grouped[b] * norm;


### PR DESCRIPTION
## 问题 / Problem

`WRAudioTap.mm` 的 `copySpectrum:` 把加窗后的**连续 1024 个样本直接作为 Ir**、Ii 传全零送进 `vDSP_DFT_Execute`：

```objc
static float zeroIn[kFFT_N];
vDSP_DFT_Execute(_dftSetup, window, zeroIn, realOut, imagOut);
```

但 `vDSP_DFT_zrop`（实数→复数 DFT）的输入约定是：**偶数下标样本放 Ir、奇数下标样本放 Ii（各 kFFT_N/2 个，即 `vDSP_ctoz` 的拆分布局）**。直接传连续窗口等于变换了另一个信号——只有前 512 个样本被读取，且全部被当作偶数位样本。

实际后果：**所有频率成分都落在真实位置一半的 bin 上，频谱高半段整体丢失**。音频可视化类壁纸显示的频谱柱仍会随音乐跳动（所以一直没被发现），但频率映射整体错误。

## 验证 / Verification

写了独立验证程序，与 double 精度朴素 DFT 参考实现对比（bin 100 处的单位幅度正弦，N=1024）：

```
参考(朴素 DFT)  : 峰 bin=100  幅度=512.00 (理论 N/2=512)
正确打包(ctoz)  : 峰 bin=100  幅度=512.00   ← 全谱最大绝对误差 0.0000
现行代码打包    : 峰 bin=50   幅度=512.00   ← 频率减半；真实 bin 100 处幅度=0
```

再复刻 `copySpectrum:` 完整管线（Hann 窗 + 分组 + 归一化 + log 压缩），48 kHz 采样下 3 kHz 正弦（理论应落在 64 柱中的第 9 柱）：

```
修复前: 峰值输出柱 = 4, 柱高 = 0.612   ← 错误位置
修复后: 峰值输出柱 = 9, 柱高 = 0.561   ← 理论正确位置，柱高量级与之前相当
```

## 修复 / Fix

1. 用 `vDSP_ctoz` 将窗口按偶/奇拆分后再执行 DFT（输入/输出缓冲区相应改为 kFFT_N/2）；
2. vDSP 实数 DFT 输出相对数学 DFT 自带 2x 系数，幅度归一化从 `2/half` 调整为 `1/half`，柱高保持在与修复前相同的量级，不会造成视觉突变。

分组循环从 bin 1 开始、最大访问 bin 448（64 组 × 7），在 kFFT_N/2 = 512 的输出缓冲内，`imagOut[0]`（Nyquist 打包位）不受影响。

已在本机通过 `WebRenderer/scripts/build.sh release` 完整构建验证。

https://claude.ai/code/session_01KzvPMuGxGW1jkwXkPRpAGi
