### PR TITLE
fix(security): resolve symlinks in the existing prefix of a contained path

### DIFF
--- a/.github/workflows/swift-logic-tests.yml
+++ b/.github/workflows/swift-logic-tests.yml
@@ -1,0 +1,39 @@
+name: Swift logic tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: swift-logic-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  swift-logic-tests:
+    name: Swift logic tests
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Select a stable Xcode
+        shell: bash
+        run: |
+          export DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
+          echo "DEVELOPER_DIR=$DEVELOPER_DIR" >> "$GITHUB_ENV"
+          xcodebuild -version
+          xcrun --sdk macosx --show-sdk-path
+
+      - name: Run logic-only Swift tests
+        shell: bash
+        run: ./Mirage/scripts/test.sh

--- a/Mirage/Mirage Wallpaper.xcodeproj/project.pbxproj
+++ b/Mirage/Mirage Wallpaper.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E100000E0000000000000000 /* PathContainment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E100000C0000000000000000 /* PathContainment.swift */; };
 		A100000B0000000000000000 /* MirageScreenSaver.saver in Copy Screen Savers */ = {isa = PBXBuildFile; fileRef = A10000010000000000000000 /* MirageScreenSaver.saver */; };
 		A10000100000000000000000 /* Mirage Screen Saver/thumbnail.png in Resources */ = {isa = PBXBuildFile; fileRef = A10000120000000000000000 /* Mirage Screen Saver/thumbnail.png */; };
 		B100000B0000000000000000 /* Mirage Login Item.app in Embed Login Items */ = {isa = PBXBuildFile; fileRef = B10000010000000000000000 /* Mirage Login Item.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -76,6 +77,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		E10000010000000000000000 /* Mirage WallpaperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Mirage WallpaperTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E100000C0000000000000000 /* PathContainment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mirage Wallpaper/Services/PathContainment.swift"; sourceTree = "<group>"; };
 		5EC47E762A2DB2E600120CCC /* Mirage Wallpaper.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Mirage Wallpaper.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000010000000000000000 /* MirageScreenSaver.saver */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MirageScreenSaver.saver; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000120000000000000000 /* Mirage Screen Saver/thumbnail.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Mirage Screen Saver/thumbnail.png"; sourceTree = "<group>"; };
@@ -102,6 +105,11 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		E10000020000000000000000 /* Mirage WallpaperTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "Mirage WallpaperTests";
+			sourceTree = "<group>";
+		};
 		A10000020000000000000000 /* Mirage Screen Saver */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -131,6 +139,13 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		E10000030000000000000000 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5EC47E732A2DB2E600120CCC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -167,6 +182,7 @@
 			isa = PBXGroup;
 			children = (
 				BB52C0202FFC254D00C34DE3 /* Mirage Wallpaper */,
+				E10000020000000000000000 /* Mirage WallpaperTests */,
 				A10000020000000000000000 /* Mirage Screen Saver */,
 				B10000020000000000000000 /* Mirage Login Item */,
 				D10000020000000000000000 /* Mirage Wallpaper Extension */,
@@ -179,6 +195,7 @@
 			isa = PBXGroup;
 			children = (
 				5EC47E762A2DB2E600120CCC /* Mirage Wallpaper.app */,
+				E10000010000000000000000 /* Mirage WallpaperTests.xctest */,
 				A10000010000000000000000 /* MirageScreenSaver.saver */,
 				B10000010000000000000000 /* Mirage Login Item.app */,
 				D10000010000000000000000 /* MirageWallpaperExtension.appex */,
@@ -198,6 +215,26 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		E10000080000000000000000 /* Mirage WallpaperTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E100000B0000000000000000 /* Build configuration list for PBXNativeTarget "Mirage WallpaperTests" */;
+			buildPhases = (
+				E10000050000000000000000 /* Sources */,
+				E10000030000000000000000 /* Frameworks */,
+				E10000040000000000000000 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				E10000020000000000000000 /* Mirage WallpaperTests */,
+			);
+			name = "Mirage WallpaperTests";
+			productName = "Mirage WallpaperTests";
+			productReference = E10000010000000000000000 /* Mirage WallpaperTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		5EC47E752A2DB2E600120CCC /* Mirage Wallpaper */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5EC47EA02A2DB2E700120CCC /* Build configuration list for PBXNativeTarget "Mirage Wallpaper" */;
@@ -302,6 +339,10 @@
 					5EC47E752A2DB2E600120CCC = {
 						CreatedOnToolsVersion = 14.3.1;
 					};
+					E10000080000000000000000 = {
+						CreatedOnToolsVersion = 16.4;
+						TestTargetID = 5EC47E752A2DB2E600120CCC;
+					};
 					B10000060000000000000000 = {
 						CreatedOnToolsVersion = 16.0;
 					};
@@ -329,6 +370,7 @@
 			projectRoot = "";
 			targets = (
 				5EC47E752A2DB2E600120CCC /* Mirage Wallpaper */,
+				E10000080000000000000000 /* Mirage WallpaperTests */,
 				A10000060000000000000000 /* MirageScreenSaver */,
 				B10000060000000000000000 /* Mirage Login Item */,
 				D10000060000000000000000 /* MirageWallpaperExtension */,
@@ -337,6 +379,13 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		E10000040000000000000000 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5EC47E742A2DB2E600120CCC /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -392,6 +441,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		E10000050000000000000000 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E100000E0000000000000000 /* PathContainment.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5EC47E722A2DB2E600120CCC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -441,6 +498,42 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		E10000090000000000000000 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.2;
+				PRODUCT_BUNDLE_IDENTIFIER = cn.laobamac.MirageTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		E100000A0000000000000000 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.2;
+				PRODUCT_BUNDLE_IDENTIFIER = cn.laobamac.MirageTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		5EC47E9E2A2DB2E700120CCC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -834,6 +927,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		E100000B0000000000000000 /* Build configuration list for PBXNativeTarget "Mirage WallpaperTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E10000090000000000000000 /* Debug */,
+				E100000A0000000000000000 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		5EC47E712A2DB2E600120CCC /* Build configuration list for PBXProject "Mirage Wallpaper" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Mirage/Mirage Wallpaper.xcodeproj/xcshareddata/xcschemes/Mirage Wallpaper.xcscheme
+++ b/Mirage/Mirage Wallpaper.xcodeproj/xcshareddata/xcschemes/Mirage Wallpaper.xcscheme
@@ -7,7 +7,7 @@
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForTesting = "YES"
+            buildForTesting = "NO"
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
@@ -17,6 +17,20 @@
                BlueprintIdentifier = "5EC47E752A2DB2E600120CCC"
                BuildableName = "Mirage Wallpaper.app"
                BlueprintName = "Mirage Wallpaper"
+               ReferencedContainer = "container:Mirage Wallpaper.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E10000080000000000000000"
+               BuildableName = "Mirage WallpaperTests.xctest"
+               BlueprintName = "Mirage WallpaperTests"
                ReferencedContainer = "container:Mirage Wallpaper.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -34,20 +48,9 @@
             parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5EC47E8B2A2DB2E700120CCC"
-               BuildableName = "Open Wallpaper EngineTests.xctest"
-               BlueprintName = "Open Wallpaper EngineTests"
-               ReferencedContainer = "container:Mirage Wallpaper.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5EC47E952A2DB2E700120CCC"
-               BuildableName = "Open Wallpaper EngineUITests.xctest"
-               BlueprintName = "Open Wallpaper EngineUITests"
+               BlueprintIdentifier = "E10000080000000000000000"
+               BuildableName = "Mirage WallpaperTests.xctest"
+               BlueprintName = "Mirage WallpaperTests"
                ReferencedContainer = "container:Mirage Wallpaper.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Mirage/Mirage Wallpaper/Services/PathContainment.swift
+++ b/Mirage/Mirage Wallpaper/Services/PathContainment.swift
@@ -58,13 +58,36 @@ enum PathContainment {
         guard !relativePath.isEmpty else {
             return (root.standardizedFileURL.resolvingSymlinksInPath(), root)
         }
-        let normalizedRoot = root.standardizedFileURL.resolvingSymlinksInPath()
-        let candidate = normalizedRoot.appending(path: relativePath)
-            .standardizedFileURL.resolvingSymlinksInPath()
+        let normalizedRoot = resolvingSymlinksInExistingPrefix(root)
+        let candidate = resolvingSymlinksInExistingPrefix(
+            normalizedRoot.appending(path: relativePath)
+        )
         // The trailing "/" matters: without it "/a/bc" would count as inside "/a/b".
         let isInside = candidate.path == normalizedRoot.path
             || candidate.path.hasPrefix(normalizedRoot.path + "/")
         guard isInside else { return nil }
         return (candidate, root.appending(path: relativePath).standardizedFileURL)
+    }
+
+    // Foundation only resolves symlinks when the complete path exists. A path
+    // such as `escape/missing.file` would otherwise leave an existing `escape`
+    // symlink unresolved. Resolve the longest existing prefix, then append the
+    // not-yet-created suffix without following it.
+    private static func resolvingSymlinksInExistingPrefix(_ url: URL) -> URL {
+        var existingPrefix = url.standardizedFileURL
+        var missingComponents: [String] = []
+
+        while !FileManager.default.fileExists(atPath: existingPrefix.path) {
+            let parent = existingPrefix.deletingLastPathComponent()
+            guard parent.path != existingPrefix.path else { break }
+            missingComponents.append(existingPrefix.lastPathComponent)
+            existingPrefix = parent
+        }
+
+        var resolved = existingPrefix.resolvingSymlinksInPath()
+        for component in missingComponents.reversed() {
+            resolved.append(path: component)
+        }
+        return resolved.standardizedFileURL
     }
 }

--- a/Mirage/Mirage WallpaperTests/PathContainmentTests.swift
+++ b/Mirage/Mirage WallpaperTests/PathContainmentTests.swift
@@ -1,0 +1,85 @@
+//
+//  Mirage WallpaperTests
+//
+//  Characterization tests for paths supplied by untrusted wallpaper manifests.
+//
+
+import Foundation
+import XCTest
+
+final class PathContainmentTests: XCTestCase {
+    private var sandbox: URL!
+    private var root: URL!
+    private var outside: URL!
+
+    override func setUpWithError() throws {
+        sandbox = FileManager.default.temporaryDirectory
+            .appending(path: "MiragePathContainmentTests-\(UUID().uuidString)", directoryHint: .isDirectory)
+        root = sandbox.appending(path: "wallpaper", directoryHint: .isDirectory)
+        outside = sandbox.appending(path: "outside", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let sandbox {
+            try? FileManager.default.removeItem(at: sandbox)
+        }
+        sandbox = nil
+        root = nil
+        outside = nil
+    }
+
+    func testAcceptsNestedPathInsideRoot() {
+        let result = PathContainment.containedURL("media/video.mp4", in: root)
+
+        XCTAssertEqual(result?.path, root.appending(path: "media/video.mp4").path)
+    }
+
+    func testAcceptsEmptyPathAsRoot() {
+        let result = PathContainment.containedURL("", in: root)
+
+        XCTAssertEqual(result?.path, root.resolvingSymlinksInPath().path)
+    }
+
+    func testRejectsParentTraversal() {
+        XCTAssertNil(PathContainment.containedURL("../outside/secret.txt", in: root))
+        XCTAssertFalse(PathContainment.isContained("nested/../../outside/secret.txt", in: root))
+    }
+
+    func testRejectsSiblingWithSharedPathPrefix() {
+        let sibling = sandbox.appending(path: "wallpaper-copy", directoryHint: .isDirectory)
+
+        XCTAssertNil(PathContainment.containedURL("../wallpaper-copy/secret.txt", in: root))
+        XCTAssertTrue(sibling.path.hasPrefix(root.path))
+    }
+
+    func testRejectsSymlinkThatEscapesRoot() throws {
+        let escape = root.appending(path: "escape")
+        try FileManager.default.createSymbolicLink(at: escape, withDestinationURL: outside)
+
+        XCTAssertNil(PathContainment.containedURL("escape/secret.txt", in: root))
+    }
+
+    func testResolvesSafeSymlinkInsideRoot() throws {
+        let media = root.appending(path: "media", directoryHint: .isDirectory)
+        let alias = root.appending(path: "alias")
+        try FileManager.default.createDirectory(at: media, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: media)
+
+        let result = PathContainment.containedURL("alias/video.mp4", in: root)
+
+        XCTAssertEqual(result?.path, media.appending(path: "video.mp4").path)
+    }
+
+    func testPreservingShapeKeepsVisibleSymlinkRoot() throws {
+        let realRoot = sandbox.appending(path: "real-wallpaper", directoryHint: .isDirectory)
+        let visibleRoot = sandbox.appending(path: "visible-wallpaper")
+        try FileManager.default.createDirectory(at: realRoot, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: visibleRoot, withDestinationURL: realRoot)
+
+        let result = PathContainment.containedURLPreservingShape("scene.pkg", in: visibleRoot)
+
+        XCTAssertEqual(result?.path, visibleRoot.appending(path: "scene.pkg").path)
+    }
+}

--- a/Mirage/scripts/test.sh
+++ b/Mirage/scripts/test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Run logic-only Swift tests without launching the Mirage app lifecycle.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIRAGE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT="$MIRAGE_DIR/Mirage Wallpaper.xcodeproj"
+SCHEME="Mirage Wallpaper"
+EXPECTED_TEST_COUNT="${MIRAGE_SWIFT_TEST_COUNT:-7}"
+
+for tool in xcodebuild xcrun python3; do
+    command -v "$tool" >/dev/null || {
+        printf 'ERROR: required tool not found: %s\n' "$tool" >&2
+        exit 1
+    }
+done
+
+architecture="$(uname -m)"
+case "$architecture" in
+    arm64|x86_64) ;;
+    *)
+        printf 'ERROR: unsupported architecture: %s\n' "$architecture" >&2
+        exit 1
+        ;;
+esac
+
+sdk_path="$(xcrun --sdk macosx --show-sdk-path)"
+sdk_name="$(basename "$sdk_path" .sdk)"
+derived_data="${MIRAGE_SWIFT_TEST_BUILD_DIR:-$MIRAGE_DIR/build/SwiftTests-${sdk_name}-${architecture}}"
+result_root="$(mktemp -d "${TMPDIR:-/tmp}/mirage-swift-tests.XXXXXX")"
+result_bundle="$result_root/MirageSwiftTests.xcresult"
+
+cleanup() {
+    status=$?
+    if [[ "$status" -eq 0 ]]; then
+        rm -rf "$result_root"
+    else
+        printf 'Swift test result retained at %s\n' "$result_bundle" >&2
+    fi
+}
+trap cleanup EXIT
+
+printf 'Running Mirage logic-only Swift tests\n'
+printf '  architecture: %s\n' "$architecture"
+printf '  SDK:          %s\n' "$sdk_path"
+printf '  Xcode:        %s\n' "$(xcodebuild -version | head -1)"
+printf '  build dir:    %s\n' "$derived_data"
+
+xcodebuild test -quiet \
+    -project "$PROJECT" \
+    -scheme "$SCHEME" \
+    -destination "platform=macOS,arch=$architecture" \
+    -only-testing:'Mirage WallpaperTests' \
+    -derivedDataPath "$derived_data" \
+    -clonedSourcePackagesDirPath "$derived_data/SourcePackages" \
+    -resultBundlePath "$result_bundle" \
+    CODE_SIGNING_ALLOWED=NO \
+    COMPILER_INDEX_STORE_ENABLE=NO \
+    ONLY_ACTIVE_ARCH=YES \
+    ARCHS="$architecture"
+
+xcrun xcresulttool get test-results tests \
+    --compact \
+    --path "$result_bundle" \
+    | python3 "$SCRIPT_DIR/validate_test_results.py" "$EXPECTED_TEST_COUNT"

--- a/Mirage/scripts/validate_test_results.py
+++ b/Mirage/scripts/validate_test_results.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Require an exact, non-zero set of passing Xcode test cases."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Iterator
+
+
+def walk(node: Any) -> Iterator[dict[str, Any]]:
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from walk(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from walk(value)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <expected-test-count>", file=sys.stderr)
+        return 2
+
+    expected_count = int(sys.argv[1])
+    payload = json.load(sys.stdin)
+    test_cases = [node for node in walk(payload) if node.get("nodeType") == "Test Case"]
+    failures = [
+        f"{node.get('name', '<unnamed>')}: {node.get('result', '<missing result>')}"
+        for node in test_cases
+        if node.get("result") != "Passed"
+    ]
+
+    if len(test_cases) != expected_count:
+        print(
+            f"ERROR: expected {expected_count} Swift tests, found {len(test_cases)}.",
+            file=sys.stderr,
+        )
+        return 1
+    if failures:
+        print("ERROR: Swift test failures:\n  " + "\n  ".join(failures), file=sys.stderr)
+        return 1
+
+    print(f"Mirage Swift tests passed ({len(test_cases)} test cases).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
从 Steam 创意工坊下载的壁纸包里，如果有人放一个指向包外面的快捷方式（symlink），Mirage 现在有可能被骗着去读包外的文件。这个 PR 堵上这个口子，并且补上一组测试，让以后改动这块代码时能自动发现类似问题。

顺带修好了一件事：项目的 Xcode scheme 里挂着两个已经不存在的测试 target，所以「测试」这个按钮其实一直是按不动的。现在换成一个真实可运行的测试 target。

---

## 问题

`PathContainment` 的注释写明：包内被植入的 symlink 不能逃出壁纸目录。但当路径的最后一段还不存在时，实现做不到这一点。

`URL.resolvingSymlinksInPath()` 只在整条路径都存在时才解析。于是 `escape/secret.txt` 这种形状 —— `escape` 是一个已经存在、指向包外的 symlink，`secret.txt` 尚未创建 —— 会以未解析的形式参与比较，直接通过围栏检查。

同一个缺口还有第二个后果：指向包内的安全 symlink 也不会被解析，于是函数返回的 URL 并不是它刚刚验证过的那条路径。注释里特意说明过「验证的文件必须就是被打开的文件」，这一点当前没有兑现。

## 改动

解析路径中**已经存在的最长前缀**，再把尚未创建的尾部原样接回去。这样既不要求资源预先存在，也能识别中间的 symlink。

代价是加载壁纸路径时多几次文件系统查询，只发生在这一处。

## 测试

新增 `Mirage WallpaperTests` target，7 个用例：嵌套路径、空路径、`..` 穿越、共享前缀的 sibling、逃逸 symlink、安全 symlink、保留形状的变体。

对当前实现跑这 7 个用例，其中 2 个失败（`testRejectsSymlinkThatEscapesRoot`、`testResolvesSafeSymlinkInsideRoot`）；应用本 PR 后 7 个全部通过。

测试是 logic-only 的：测试包直接编译生产环境的那一份 `PathContainment.swift`，不寄宿在主 App 里。所以跑测试不会启动 Mirage 的生命周期、不读用户偏好、不碰桌面状态。

## 关于 scheme 和工程文件

共享 scheme 之前引用 `Open Wallpaper EngineTests` 和 `Open Wallpaper EngineUITests`，这两个 target 在工程里并不存在，测试动作无法执行。本 PR 把它们替换为新的测试 target。

新加的工程对象使用 `E1…` 前缀的 ID，避开 `Mirage Wallpaper Extension` 已经占用的 `D1…` 段。

CI 里加了一个 workflow，跑 `./Mirage/scripts/test.sh`。runner 在实际执行数为 0 时会让构建失败，避免出现「一个测试都没跑但显示绿色」的情况。

## 验证环境

macOS 27.0 beta（26A5416b）/ Apple Silicon，Xcode 26.6（17F113），macOS SDK 26.5。基于 `main` 的 `e36d37d`（v1.1.0）。
