### PR TITLE
test(ci): run the existing SceneRenderer regressions on both architectures

### DIFF
--- a/.github/workflows/scene-renderer-regressions.yml
+++ b/.github/workflows/scene-renderer-regressions.yml
@@ -1,0 +1,67 @@
+name: SceneRenderer regressions
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scene-regressions-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scene-regressions:
+    name: SceneRenderer regressions (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-15
+            preset: macos-arm64-clang-release
+          - arch: x86_64
+            runner: macos-15-intel
+            preset: macos-clang-release
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    env:
+      BUILD_PRESET: ${{ matrix.preset }}
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Select a stable Xcode
+        shell: bash
+        run: |
+          stable_xcode="/Applications/Xcode.app"
+          if [[ ! -d "$stable_xcode" ]]; then
+            stable_xcode="$(find /Applications -maxdepth 1 -type d -name 'Xcode*.app' \
+              ! -iname '*beta*' ! -iname '*rc*' | sort | tail -1)"
+          fi
+          if [[ -z "$stable_xcode" ]]; then
+            echo "::error::No stable Xcode installation found."
+            exit 1
+          fi
+          export DEVELOPER_DIR="$stable_xcode/Contents/Developer"
+          echo "DEVELOPER_DIR=$DEVELOPER_DIR" >> "$GITHUB_ENV"
+          xcodebuild -version
+          xcrun --sdk macosx --show-sdk-path
+
+      - name: Install SceneRenderer test dependencies
+        shell: bash
+        run: |
+          brew install cmake ninja pkg-config llvm molten-vk vulkan-loader \
+            vulkan-headers glslang freetype fontconfig lz4 ffmpeg
+
+      - name: Run SceneRenderer regression suite
+        shell: bash
+        run: ./SceneRenderer/scripts/test.sh

--- a/SceneRenderer/scripts/test.sh
+++ b/SceneRenderer/scripts/test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Build and run the SceneRenderer regression suite in an isolated CMake tree.
+# The normal renderer build cache is intentionally left untouched so this gate
+# can run before and after refactors without changing packaged artifacts.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROOT_DIR="$(cd "$PROJECT_DIR/.." && pwd)"
+
+source "$ROOT_DIR/scripts/preset.sh"
+
+[[ "$(uname -s)" == "Darwin" ]] || {
+    printf 'ERROR: SceneRenderer regression tests currently require macOS.\n' >&2
+    exit 1
+}
+
+for tool in brew cmake ninja ctest; do
+    command -v "$tool" >/dev/null || {
+        printf 'ERROR: required tool not found: %s\n' "$tool" >&2
+        exit 1
+    }
+done
+
+PRESET="${BUILD_PRESET:-$(scene_preset release)}"
+case "$PRESET" in
+    macos-clang-release|macos-clang-debug|macos-arm64-clang-release|macos-arm64-clang-debug) ;;
+    *)
+        printf 'ERROR: unsupported BUILD_PRESET: %s\n' "$PRESET" >&2
+        exit 1
+        ;;
+esac
+
+LLVM_PREFIX="$(brew --prefix llvm)"
+CLANG_BIN="$LLVM_PREFIX/bin/clang"
+CLANGXX_BIN="$LLVM_PREFIX/bin/clang++"
+[[ -x "$CLANG_BIN" && -x "$CLANGXX_BIN" ]] || {
+    printf 'ERROR: Homebrew LLVM is not installed at %s.\n' "$LLVM_PREFIX" >&2
+    exit 1
+}
+
+command -v xcrun >/dev/null || {
+    printf 'ERROR: xcrun is required to select a macOS SDK.\n' >&2
+    exit 1
+}
+
+# Resolve the SDK through the selected Xcode. CMake otherwise may discover the
+# separately installed Command Line Tools SDK, producing an unauditable mix of
+# headers and frameworks from different toolchains.
+SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
+[[ -d "$SDK_PATH" ]] || {
+    printf 'ERROR: selected macOS SDK does not exist: %s\n' "$SDK_PATH" >&2
+    exit 1
+}
+SDK_NAME="$(basename "$SDK_PATH" .sdk)"
+
+# Keep stable and beta SDK caches physically separate. This prevents CMake's
+# cached find_library results from carrying framework paths across SDKs.
+BUILD_DIR="${SCENERENDERER_TEST_BUILD_DIR:-$PROJECT_DIR/build/${PRESET}-${SDK_NAME}-tests}"
+JOBS="${JOBS:-$(sysctl -n hw.logicalcpu 2>/dev/null || printf '8')}"
+
+cd "$PROJECT_DIR"
+
+printf 'Configuring SceneRenderer regression tests\n'
+printf '  preset:    %s\n' "$PRESET"
+printf '  SDK:       %s\n' "$SDK_PATH"
+printf '  compiler:  %s\n' "$($CLANGXX_BIN --version | head -1)"
+printf '  build dir: %s\n' "$BUILD_DIR"
+
+cmake --preset "$PRESET" \
+    -B "$BUILD_DIR" \
+    -DCMAKE_C_COMPILER="$CLANG_BIN" \
+    -DCMAKE_CXX_COMPILER="$CLANGXX_BIN" \
+    -DCMAKE_OSX_SYSROOT="$SDK_PATH" \
+    -DSCENERENDERER_BUILD_TESTS=ON \
+    -DSCENERENDERER_BUILD_VIEWER=OFF \
+    -DSCENERENDERER_BUILD_WALLPAPER_HOST=OFF
+
+TEST_TARGETS=(
+    SceneRendererTextGeometryTests
+    SceneRendererLayerVisibilityTests
+    SceneRendererRuntimeCompatibilityTests
+    SceneRendererScriptCompatibilityTests
+    SceneRendererPuppetAlphaTests
+)
+
+cmake --build "$BUILD_DIR" \
+    --parallel "$JOBS" \
+    --target "${TEST_TARGETS[@]}"
+
+test_count="$(ctest --test-dir "$BUILD_DIR" -N | awk '/Total Tests:/ { print $3 }')"
+if [[ "$test_count" != "${#TEST_TARGETS[@]}" ]]; then
+    printf 'ERROR: expected %d tests, discovered %s.\n' \
+        "${#TEST_TARGETS[@]}" "${test_count:-0}" >&2
+    exit 1
+fi
+
+ctest --test-dir "$BUILD_DIR" \
+    --output-on-failure \
+    --no-tests=error


### PR DESCRIPTION
项目里其实已经写好了 5 个 SceneRenderer 的回归测试，但默认是关掉的，CI 也没有跑过它们。也就是说改渲染器的时候，这 5 个测试帮不上忙。这个 PR 只做一件事：让它们在每次提交时自动跑起来，Intel 和 Apple Silicon 各跑一遍。

不改任何产品代码、打包方式或发布行为。

---

## 现状

`SceneRenderer/CMakeLists.txt` 里 `SCENERENDERER_BUILD_TESTS` 默认为 `OFF`，`build-macos.yml` 也没有开启它或调用 `ctest`。所以 `SceneRenderer/Tests` 下的 5 个测试从未在 CI 中执行。

## 改动

- `SceneRenderer/scripts/test.sh`：配置一个独立的 CMake build tree（开启测试），运行 `ctest`。
- `.github/workflows/scene-renderer-regressions.yml`：在 `macos-15` 和 `macos-15-intel` 上各跑一次。

两个实现细节值得说明：

**build tree 是隔离的。** 目录名带上 preset 和 SDK 名，不复用也不污染打包渲染器用的那份缓存。这样门禁可以在重构前后反复跑，不影响构建产物。

**显式指定 `CMAKE_OSX_SYSROOT`。** 本机首次运行时遇到过一个问题：即使设置了 `DEVELOPER_DIR`，CMake 仍然从单独安装的 Command Line Tools 里缓存了另一个版本的 macOS SDK framework 路径，导致 Metal header 编译失败。所以这里按所选 Xcode 的 SDK 显式固定，并按 SDK 名隔离 build tree。

workflow 里选的是稳定版 Xcode 而不是最新版（`build-macos.yml` 选的是最新版），原因同上：beta 工具链和正式版混用会让测试结果不可复现。这个差异如果你更希望保持一致，我可以改。

## 结果

- 本机（Apple Silicon，Xcode 26.6，macOS SDK 26.5）：5/5 通过，约 42 秒。
- 之前在 fork 的 CI 上跑过同一套脚本：`macos-15` 5/5、`macos-15-intel` 5/5，Intel 约 5 分钟（851 个 C++ 编译步骤，比 arm64 慢是正常的）。

## 一个已知的、本 PR 没有解决的问题

链接阶段可以看到，Homebrew 的 Vulkan、FFmpeg、LZ4、FreeType、Fontconfig 都是按 macOS 26.0 或更高版本构建的，而项目声明的 deployment target 是 14.2：

```
ld: warning: building for macOS-14.2, but linking with dylib
'/opt/homebrew/opt/freetype/lib/libfreetype.6.dylib' which was built for newer version 26.0
```

所以这套门禁只能证明「当前 runner 上测试通过」，不能证明产物能在 macOS 14.2 上运行。要真正验证最低系统版本，需要把发布依赖固定成与 deployment target 一致的构建产物。这属于另一个话题，我没有放进这个 PR。
