### PR TITLE
test(steam-service): add a credential-free IPC contract gate

### DIFF
--- a/.github/workflows/steam-service-contract.yml
+++ b/.github/workflows/steam-service-contract.yml
@@ -1,0 +1,40 @@
+name: SteamService contract
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: steam-service-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  steam-service-contract:
+    name: SteamService IPC contract
+    runs-on: macos-15
+    timeout-minutes: 30
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+          cache: true
+          cache-dependency-path: SteamService/packages.lock.json
+
+      - name: Package the service and exercise its IPC contract
+        shell: bash
+        run: ./SteamService/scripts/test.sh

--- a/Mirage/scripts/build_steam_service.sh
+++ b/Mirage/scripts/build_steam_service.sh
@@ -13,15 +13,33 @@ ARCHITECTURES="${3:-$(uname -m)}"
 PROJECT="$ROOT/SteamService/MirageSteamService.csproj"
 OUTPUT="$ROOT/Mirage/build/SteamService"
 DESTINATION="$APP/Contents/Resources/SteamService"
-DOTNET_EXECUTABLE="$(python3 -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' "$(command -v dotnet)")"
-DOTNET_ROOT="$(dirname "$DOTNET_EXECUTABLE")"
-RUNTIME_VERSION="$(dotnet --list-runtimes | awk '$1 == "Microsoft.NETCore.App" && $2 ~ /^10\./ { print $2 }' | sort -V | tail -1)"
+RUNTIME_ENTRY="$(
+    dotnet --list-runtimes \
+        | awk '$1 == "Microsoft.NETCore.App" && $2 ~ /^10\./ { gsub(/^\[|\]$/, "", $3); print $2, $3 }' \
+        | sort -V \
+        | tail -1
+)"
+[ -n "$RUNTIME_ENTRY" ] || { echo "[steam-service] Microsoft.NETCore.App 10 runtime is unavailable" >&2; exit 1; }
+read -r RUNTIME_VERSION RUNTIME_SHARED_PATH <<< "$RUNTIME_ENTRY"
+[ -d "$RUNTIME_SHARED_PATH" ] || { echo "[steam-service] runtime directory is unavailable at $RUNTIME_SHARED_PATH" >&2; exit 1; }
+DOTNET_ROOT="$(cd "$RUNTIME_SHARED_PATH/../.." 2>/dev/null && pwd -P)"
+DOTNET_EXECUTABLE="$DOTNET_ROOT/dotnet"
+DOTNET_LICENSE="$DOTNET_ROOT/LICENSE.txt"
+DOTNET_NOTICES="$DOTNET_ROOT/ThirdPartyNotices.txt"
 
-[ -n "$RUNTIME_VERSION" ] || { echo "[steam-service] Microsoft.NETCore.App 10 runtime is unavailable" >&2; exit 1; }
+# The official installer keeps notices at DOTNET_ROOT, while Homebrew places
+# them under the formula prefix's share/doc/dotnet directory.
+if [ ! -f "$DOTNET_LICENSE" ] || [ ! -f "$DOTNET_NOTICES" ]; then
+    DOTNET_DOCUMENTATION_ROOT="$DOTNET_ROOT/../share/doc/dotnet"
+    DOTNET_LICENSE="$DOTNET_DOCUMENTATION_ROOT/LICENSE.txt"
+    DOTNET_NOTICES="$DOTNET_DOCUMENTATION_ROOT/ThirdPartyNotices.txt"
+fi
+
+[ -x "$DOTNET_EXECUTABLE" ] || { echo "[steam-service] dotnet host is unavailable at $DOTNET_EXECUTABLE" >&2; exit 1; }
 [ -d "$DOTNET_ROOT/host/fxr/$RUNTIME_VERSION" ] || { echo "[steam-service] hostfxr $RUNTIME_VERSION is unavailable" >&2; exit 1; }
 [ -d "$DOTNET_ROOT/shared/Microsoft.NETCore.App/$RUNTIME_VERSION" ] || { echo "[steam-service] runtime $RUNTIME_VERSION is unavailable" >&2; exit 1; }
-[ -f "$DOTNET_ROOT/LICENSE.txt" ] || { echo "[steam-service] .NET license is unavailable" >&2; exit 1; }
-[ -f "$DOTNET_ROOT/ThirdPartyNotices.txt" ] || { echo "[steam-service] .NET third-party notices are unavailable" >&2; exit 1; }
+[ -f "$DOTNET_LICENSE" ] || { echo "[steam-service] .NET license is unavailable" >&2; exit 1; }
+[ -f "$DOTNET_NOTICES" ] || { echo "[steam-service] .NET third-party notices are unavailable" >&2; exit 1; }
 
 rm -rf "$DESTINATION"
 mkdir -p "$DESTINATION/Licenses"
@@ -46,7 +64,7 @@ publish_architecture() {
         -p:PublishTrimmed=false \
         -p:DebugType=None \
         -p:DebugSymbols=false \
-        "${restore_options[@]}" \
+        ${restore_options[@]+"${restore_options[@]}"} \
         -o "$OUTPUT/$runtime"
     mkdir -p "$application_destination" "$runtime_destination/host/fxr" "$runtime_destination/shared/Microsoft.NETCore.App"
     cp -R "$OUTPUT/$runtime/." "$application_destination/"
@@ -86,5 +104,5 @@ fi
 cp -f "$ROOT/SteamService/Licenses/LGPL-2.1.txt" "$DESTINATION/Licenses/LGPL-2.1.txt"
 cp -f "$ROOT/SteamService/Licenses/SteamKit2-NOTICE.txt" "$DESTINATION/Licenses/SteamKit2-NOTICE.txt"
 cp -f "$ROOT/SteamService/Licenses/DepotDownloader-NOTICE.txt" "$DESTINATION/Licenses/DepotDownloader-NOTICE.txt"
-cp -f "$DOTNET_ROOT/LICENSE.txt" "$DESTINATION/Licenses/dotnet-LICENSE.txt"
-cp -f "$DOTNET_ROOT/ThirdPartyNotices.txt" "$DESTINATION/Licenses/dotnet-ThirdPartyNotices.txt"
+cp -f "$DOTNET_LICENSE" "$DESTINATION/Licenses/dotnet-LICENSE.txt"
+cp -f "$DOTNET_NOTICES" "$DESTINATION/Licenses/dotnet-ThirdPartyNotices.txt"

--- a/SteamService/scripts/smoke_test.py
+++ b/SteamService/scripts/smoke_test.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Exercise the credential-free SteamService JSON-lines protocol."""
+
+from __future__ import annotations
+
+import json
+import selectors
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+TIMEOUT_SECONDS = 10
+
+
+def fail(message: str) -> None:
+    raise AssertionError(message)
+
+
+def read_message(process: subprocess.Popen[str]) -> dict[str, Any]:
+    assert process.stdout is not None
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ)
+    try:
+        if not selector.select(TIMEOUT_SECONDS):
+            fail(f"SteamService produced no response within {TIMEOUT_SECONDS} seconds")
+        line = process.stdout.readline()
+    finally:
+        selector.close()
+
+    if not line:
+        fail(f"SteamService exited before responding (exit={process.poll()})")
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError as error:
+        fail(f"SteamService produced invalid JSON: {error}: {line!r}")
+    if not isinstance(payload, dict):
+        fail(f"SteamService response is not an object: {payload!r}")
+    return payload
+
+
+def send(process: subprocess.Popen[str], payload: dict[str, Any] | str) -> dict[str, Any]:
+    assert process.stdin is not None
+    line = payload if isinstance(payload, str) else json.dumps(payload, separators=(",", ":"))
+    process.stdin.write(line + "\n")
+    process.stdin.flush()
+    return read_message(process)
+
+
+def expect_fields(payload: dict[str, Any], **expected: Any) -> None:
+    for key, value in expected.items():
+        if payload.get(key) != value:
+            fail(f"expected {key}={value!r}, received {payload!r}")
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(
+            f"usage: {Path(sys.argv[0]).name} <dotnet-host> <MirageSteamService.dll>",
+            file=sys.stderr,
+        )
+        return 2
+
+    dotnet_host = Path(sys.argv[1]).resolve()
+    assembly = Path(sys.argv[2]).resolve()
+    if not dotnet_host.is_file():
+        print(f"bundled dotnet host not found: {dotnet_host}", file=sys.stderr)
+        return 2
+    if not assembly.is_file():
+        print(f"SteamService assembly not found: {assembly}", file=sys.stderr)
+        return 2
+
+    process = subprocess.Popen(
+        [str(dotnet_host), str(assembly)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+
+    try:
+        hello = send(process, {"command": "hello", "requestId": "hello-smoke"})
+        expect_fields(
+            hello,
+            type="hello",
+            requestId="hello-smoke",
+            version="1.0.0",
+            maxConcurrentDownloads=3,
+        )
+
+        pong = send(process, {"command": "ping", "requestId": "ping-smoke"})
+        expect_fields(pong, type="pong", requestId="ping-smoke")
+
+        malformed = send(process, "{")
+        expect_fields(malformed, type="response", success=False)
+
+        missing = send(process, {"requestId": "missing-command-smoke"})
+        expect_fields(
+            missing,
+            type="response",
+            requestId="missing-command-smoke",
+            success=False,
+            errorCode="INVALID_COMMAND",
+        )
+
+        unsupported = send(
+            process,
+            {"command": "notARealCommand", "requestId": "unsupported-smoke"},
+        )
+        expect_fields(
+            unsupported,
+            type="response",
+            requestId="unsupported-smoke",
+            success=False,
+            errorCode="UNSUPPORTED_COMMAND",
+        )
+
+        shutdown = send(process, {"command": "shutdown", "requestId": "shutdown-smoke"})
+        expect_fields(
+            shutdown,
+            type="response",
+            requestId="shutdown-smoke",
+            success=True,
+        )
+
+        process.wait(timeout=TIMEOUT_SECONDS)
+        if process.returncode != 0:
+            fail(f"SteamService exited with status {process.returncode}")
+        print("SteamService IPC smoke test passed (6 commands).")
+        return 0
+    except Exception:
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=2)
+        assert process.stderr is not None
+        stderr = process.stderr.read().strip()
+        if stderr:
+            print(f"SteamService stderr:\n{stderr}", file=sys.stderr)
+        raise
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/SteamService/scripts/test.sh
+++ b/SteamService/scripts/test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Build SteamService from the lock file, then exercise its local IPC contract.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVICE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROOT_DIR="$(cd "$SERVICE_DIR/.." && pwd)"
+
+for tool in dotnet file python3; do
+    command -v "$tool" >/dev/null || {
+        printf 'ERROR: required tool not found: %s\n' "$tool" >&2
+        exit 1
+    }
+done
+
+architecture="$(uname -m)"
+case "$architecture" in
+    arm64|x86_64) ;;
+    *)
+        printf 'ERROR: unsupported architecture: %s\n' "$architecture" >&2
+        exit 1
+        ;;
+esac
+
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/mirage-steam-service-smoke.XXXXXX")"
+cleanup() {
+    rm -rf "$test_root"
+}
+trap cleanup EXIT
+
+printf 'Building SteamService IPC smoke-test fixture\n'
+printf '  architecture: %s\n' "$architecture"
+printf '  dotnet:  %s\n' "$(dotnet --version)"
+
+app="$test_root/Mirage.app"
+bash "$ROOT_DIR/Mirage/scripts/build_steam_service.sh" \
+    "$app" \
+    "$ROOT_DIR" \
+    "$architecture"
+
+service="$app/Contents/Resources/SteamService/$architecture"
+runtime="$service/runtime"
+assembly="$service/app/MirageSteamService.dll"
+
+test -x "$runtime/dotnet"
+test -f "$assembly"
+test -f "$service/app/SteamKit2.dll"
+test -f "$app/Contents/Resources/SteamService/Licenses/LGPL-2.1.txt"
+test -f "$app/Contents/Resources/SteamService/Licenses/SteamKit2-NOTICE.txt"
+test -f "$app/Contents/Resources/SteamService/Licenses/dotnet-LICENSE.txt"
+test -f "$app/Contents/Resources/SteamService/Licenses/dotnet-ThirdPartyNotices.txt"
+file "$runtime/dotnet" | grep -q "$architecture"
+
+DOTNET_ROOT="$runtime" python3 "$SCRIPT_DIR/smoke_test.py" \
+    "$runtime/dotnet" \
+    "$assembly"


### PR DESCRIPTION
现在如果 SteamService 的打包方式或者它和主 App 的通信协议被改坏了，要等到真正打包发版的时候才会发现。这个 PR 加了一道自动检查：每次提交都真的把服务打包一遍，再用 6 条最基础的消息试一下它还能不能正常对话。

整个过程不需要 Steam 账号、不需要 API key、不联网。

---

## 改动

`SteamService/scripts/test.sh` 会：

1. 调用**真实的** `Mirage/scripts/build_steam_service.sh`，打进一个临时的 `Mirage.app`；
2. 检查内嵌 runtime、`MirageSteamService.dll`、`SteamKit2.dll`，以及必须随包分发的那几个许可证文件；
3. 核对 `dotnet` host 的架构；
4. 用 `smoke_test.py` 走 6 条协议：`hello`、`ping`、非法 JSON、缺失 command 字段、未知命令、`shutdown`。

选择调用真实打包脚本而不是只测编译产物，是因为之前几次实际失败都发生在打包这一层，而不是 C# 代码里。

## 顺带修的两个打包兼容问题

这两个问题让脚本在发布 runner 之外的环境跑不起来：

**1. 假设了官方安装器的目录布局。**

原来的脚本从 `command -v dotnet` 反推 `DOTNET_ROOT`，并要求 `LICENSE.txt` 和 `ThirdPartyNotices.txt` 就在该目录下。Homebrew 安装的 .NET 不是这个布局——runtime 在别处，许可证放在 `share/doc/dotnet`。结果是运行时明明可用，脚本却直接中止。

改成从 `dotnet --list-runtimes` 读取真实 runtime 路径，并同时接受官方安装器和 Homebrew 两种许可证位置。**没有放宽许可证检查**，两个文件仍然必须存在才能继续。

**2. Bash 3.2 下的空数组展开。**

macOS 自带的是 Bash 3.2。在 `set -u` 下，`"${restore_options[@]}"` 在数组为空时会被当作未绑定变量而报错。发布 CI 因为 `CI=true` 恰好让这个数组非空，所以一直没暴露；本机跑就会失败。

改成 `${restore_options[@]+"${restore_options[@]}"}`。locked-mode restore 仍然只在 CI 下启用，行为没有变化。

## 结果

本机（Apple Silicon，.NET 10.0.301）两种模式都验证过：

- 默认（非 locked）：6/6 通过，约 3 秒
- `CI=true`（locked mode）：6/6 通过

之前在 fork 的 CI 上跑过同一套脚本，33 秒通过。

## 一个可选的后续项，没有放进这个 PR

`build_steam_service.sh` 目前只在 `CI=true` 时启用 locked-mode restore。本机构建时锁文件可以被静默改写，因此本机能过、CI 不一定能过。始终启用 locked mode 会让这个差异消失，但这属于策略变更而不是兼容性修复，所以我保持了原有行为。如果你觉得值得改，我另开一个 PR。
