### PR TITLE
refactor(workshop): coalesce and cancel image loading requests

### DIFF
--- a/Mirage/Mirage Wallpaper/ContentView/Components/Workshop/WorkshopItemDetail.swift
+++ b/Mirage/Mirage Wallpaper/ContentView/Components/Workshop/WorkshopItemDetail.swift
@@ -56,7 +56,8 @@ struct WorkshopItemDetail: View {
                 WorkshopImage(
                     url: item.previewImageURL,
                     contentMode: .fill,
-                    isAnimating: isActive
+                    isAnimating: isActive,
+                    isLoadingEnabled: isActive
                 )
                     .frame(width: 280, height: 280)
                     .clipShape(RoundedRectangle(cornerRadius: 12))

--- a/Mirage/Mirage Wallpaper/ContentView/ContentView.swift
+++ b/Mirage/Mirage Wallpaper/ContentView/ContentView.swift
@@ -179,7 +179,9 @@ struct ContentView: View {
                         WorkshopItemDetail(
                             item: workshopViewModel.selectedItem,
                             workshopViewModel: workshopViewModel,
-                            isActive: navigationModel.selection != .installed && workshopViewModel.showCustomization == false
+                            isActive: workshopViewModel.showCreatorProfile == false &&
+                                navigationModel.selection != .installed &&
+                                workshopViewModel.showCustomization == false
                         )
                             .frame(maxWidth: 320)
                             .sectionVisibility(

--- a/Mirage/Mirage Wallpaper/GlobalComponents/WorkshopImage.swift
+++ b/Mirage/Mirage Wallpaper/GlobalComponents/WorkshopImage.swift
@@ -9,8 +9,36 @@ import CryptoKit
 import ImageIO
 import SwiftUI
 
-final class WorkshopImageLoader {
+actor WorkshopImageLoader {
     static let shared = WorkshopImageLoader()
+
+    // Images are fully prepared before publication and are never mutated by the loader.
+    struct LoadedImage: @unchecked Sendable {
+        let image: NSImage
+        let animationData: Data?
+    }
+
+    private struct RequestKey: Hashable, Sendable {
+        let url: URL
+        let maxPixel: Int
+    }
+
+    private struct PreparedImage: @unchecked Sendable {
+        let image: NSImage
+        let animationData: Data?
+        let sourceData: Data
+    }
+
+    private struct PendingLoad {
+        let generationID: UUID
+        let task: Task<Void, Never>
+        var subscribers: [UUID: CheckedContinuation<LoadedImage, Error>]
+    }
+
+    private enum LoadError: Error {
+        case invalidData
+        case invalidResponse
+    }
 
     private let memory: NSCache<NSString, NSImage> = {
         let cache = NSCache<NSString, NSImage>()
@@ -32,26 +60,34 @@ final class WorkshopImageLoader {
         return cache
     }()
 
-    private let ioQueue = DispatchQueue(
-        label: "cn.laobamac.Mirage.workshopImage", qos: .userInitiated, attributes: .concurrent)
-    private let ioLimiter = DispatchSemaphore(value: 4)
+    private let session: URLSession
+    private let diskDirectory: URL
+    private var pendingLoads: [RequestKey: PendingLoad] = [:]
 
-    private let session: URLSession = {
+    private static func makeSession() -> URLSession {
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = 20
         configuration.timeoutIntervalForResource = 40
         configuration.httpMaximumConnectionsPerHost = 6
         return URLSession(configuration: configuration)
-    }()
+    }
 
-    private let diskDirectory: URL = {
+    private static func makeDiskDirectory() -> URL {
         let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
             .appending(path: "Mirage/WorkshopImageCache")
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir
-    }()
+    }
 
-    private func maxPixel(for size: CGSize, scale: CGFloat) -> Int {
+    init(
+        session: URLSession = WorkshopImageLoader.makeSession(),
+        diskDirectory: URL = WorkshopImageLoader.makeDiskDirectory()
+    ) {
+        self.session = session
+        self.diskDirectory = diskDirectory
+    }
+
+    static func maxPixel(for size: CGSize, scale: CGFloat) -> Int {
         let raw = Double(max(size.width, size.height)) * Double(max(scale, 1))
         let bucket = (raw / 64).rounded(.up) * 64
         return max(64, min(Int(bucket), 2048))
@@ -61,7 +97,7 @@ final class WorkshopImageLoader {
         "\(url.absoluteString)#\(px)" as NSString
     }
 
-    private func diskURL(for url: URL) -> URL {
+    private static func diskURL(for url: URL, in diskDirectory: URL) -> URL {
         let digest = SHA256.hash(data: Data(url.absoluteString.utf8))
             .map { String(format: "%02x", $0) }.joined()
         return diskDirectory.appending(path: digest)
@@ -72,10 +108,6 @@ final class WorkshopImageLoader {
         return max(1, rep.pixelsWide * rep.pixelsHigh * 4)
     }
 
-    func cachedImage(url: URL, targetSize: CGSize, scale: CGFloat) -> NSImage? {
-        memory.object(forKey: memoryKey(url, maxPixel(for: targetSize, scale: scale)))
-    }
-
     private func cachedAnimatedFlag(_ url: URL) -> Bool? {
         animatedFlags.object(forKey: url.absoluteString as NSString)?.boolValue
     }
@@ -84,79 +116,174 @@ final class WorkshopImageLoader {
         animatedFlags.setObject(NSNumber(value: value), forKey: url.absoluteString as NSString)
     }
 
-    func load(url: URL, targetSize: CGSize, scale: CGFloat,
-              completion: @escaping (NSImage?, Data?) -> Void) {
-        let px = maxPixel(for: targetSize, scale: scale)
-        let key = memoryKey(url, px)
+    func load(url: URL, targetSize: CGSize, scale: CGFloat) async throws -> LoadedImage {
+        try await load(
+            url: url,
+            maxPixel: Self.maxPixel(for: targetSize, scale: scale)
+        )
+    }
+
+    func load(url: URL, maxPixel: Int) async throws -> LoadedImage {
+        try Task.checkCancellation()
+
+        let requestKey = RequestKey(url: url, maxPixel: maxPixel)
+        let imageKey = memoryKey(url, maxPixel)
         let dataKey = url.absoluteString as NSString
-        if let image = memory.object(forKey: key), let animated = cachedAnimatedFlag(url) {
+        if let image = memory.object(forKey: imageKey),
+           let animated = cachedAnimatedFlag(url) {
             guard animated else {
-                completion(image, nil)
-                return
+                return LoadedImage(image: image, animationData: nil)
             }
             if let cachedData = dataMemory.object(forKey: dataKey) {
-                completion(image, cachedData as Data)
-                return
+                return LoadedImage(image: image, animationData: cachedData as Data)
             }
         }
-        ioQueue.async { [weak self] in
-            guard let self else { return }
-            self.ioLimiter.wait()
-            defer { self.ioLimiter.signal() }
-            if url.isFileURL {
-                guard let data = try? Data(contentsOf: url, options: .mappedIfSafe),
-                      !data.isEmpty,
-                      let image = Self.downsample(data, maxPixel: px) else {
-                    DispatchQueue.main.async { completion(nil, nil) }
-                    return
-                }
-                let animatedData = Self.safeAnimationData(data)
-                let animated = animatedData != nil
-                self.setAnimatedFlag(animated, for: url)
-                self.store(data: data, image: image, dataKey: dataKey,
-                           imageKey: key, animated: animated)
-                DispatchQueue.main.async {
-                    completion(image, animatedData)
-                }
-                return
+
+        let subscriberID = UUID()
+        let loaded = try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            return try await withCheckedThrowingContinuation { continuation in
+                subscribe(
+                    subscriberID: subscriberID,
+                    to: requestKey,
+                    continuation: continuation
+                )
             }
-            let disk = self.diskURL(for: url)
-            if let data = try? Data(contentsOf: disk), !data.isEmpty,
-               let image = Self.downsample(data, maxPixel: px) {
-                let animatedData = Self.safeAnimationData(data)
-                let animated = animatedData != nil
-                self.setAnimatedFlag(animated, for: url)
-                self.store(data: data, image: image, dataKey: dataKey,
-                           imageKey: key, animated: animated)
-                DispatchQueue.main.async {
-                    completion(image, animatedData)
-                }
-                return
+        } onCancel: {
+            Task {
+                await self.cancelSubscriber(subscriberID, from: requestKey)
             }
-            let semaphore = DispatchSemaphore(value: 0)
-            self.session.dataTask(with: URLRequest(url: url)) { [weak self] data, response, _ in
-                defer { semaphore.signal() }
-                guard let self else { return }
-                let ok = (response as? HTTPURLResponse).map { (200..<300).contains($0.statusCode) } ?? true
-                guard ok, let data, !data.isEmpty else {
-                    DispatchQueue.main.async { completion(nil, nil) }
-                    return
-                }
-                try? data.write(to: disk, options: .atomic)
-                let image = Self.downsample(data, maxPixel: px)
-                let animatedData = Self.safeAnimationData(data)
-                let animated = animatedData != nil
-                self.setAnimatedFlag(animated, for: url)
-                if let image {
-                    self.store(data: data, image: image, dataKey: dataKey,
-                               imageKey: key, animated: animated)
-                }
-                DispatchQueue.main.async {
-                    completion(image, animatedData)
-                }
-            }.resume()
-            semaphore.wait()
         }
+        try Task.checkCancellation()
+        return loaded
+    }
+
+    private func subscribe(
+        subscriberID: UUID,
+        to key: RequestKey,
+        continuation: CheckedContinuation<LoadedImage, Error>
+    ) {
+        if var pending = pendingLoads[key] {
+            pending.subscribers[subscriberID] = continuation
+            pendingLoads[key] = pending
+            return
+        }
+
+        let requestID = UUID()
+        let session = session
+        let diskDirectory = diskDirectory
+        let task = Task.detached(priority: .userInitiated) {
+            let result: Result<PreparedImage, Error>
+            do {
+                let prepared = try await Self.fetch(
+                    key: key,
+                    session: session,
+                    diskDirectory: diskDirectory
+                )
+                result = .success(prepared)
+            } catch {
+                result = .failure(error)
+            }
+            await self.finish(key: key, requestID: requestID, result: result)
+        }
+        pendingLoads[key] = PendingLoad(
+            generationID: requestID,
+            task: task,
+            subscribers: [subscriberID: continuation]
+        )
+    }
+
+    private func cancelSubscriber(_ subscriberID: UUID, from key: RequestKey) {
+        guard var pending = pendingLoads[key],
+              let continuation = pending.subscribers.removeValue(forKey: subscriberID) else {
+            return
+        }
+
+        continuation.resume(throwing: CancellationError())
+        if pending.subscribers.isEmpty {
+            pendingLoads.removeValue(forKey: key)
+            pending.task.cancel()
+        } else {
+            pendingLoads[key] = pending
+        }
+    }
+
+    private func finish(
+        key: RequestKey,
+        requestID: UUID,
+        result: Result<PreparedImage, Error>
+    ) {
+        // A fully cancelled generation may have been replaced for the same key.
+        guard let pending = pendingLoads[key],
+              pending.generationID == requestID else { return }
+        pendingLoads.removeValue(forKey: key)
+
+        let subscriberResult: Result<LoadedImage, Error>
+        switch result {
+        case .success(let prepared):
+            let animated = prepared.animationData != nil
+            setAnimatedFlag(animated, for: key.url)
+            store(
+                data: prepared.sourceData,
+                image: prepared.image,
+                dataKey: key.url.absoluteString as NSString,
+                imageKey: memoryKey(key.url, key.maxPixel),
+                animated: animated
+            )
+            subscriberResult = .success(
+                LoadedImage(image: prepared.image, animationData: prepared.animationData)
+            )
+        case .failure(let error):
+            subscriberResult = .failure(error)
+        }
+
+        for continuation in pending.subscribers.values {
+            continuation.resume(with: subscriberResult)
+        }
+    }
+
+    private static func fetch(
+        key: RequestKey,
+        session: URLSession,
+        diskDirectory: URL
+    ) async throws -> PreparedImage {
+        try Task.checkCancellation()
+
+        if key.url.isFileURL {
+            let data = try Data(contentsOf: key.url, options: .mappedIfSafe)
+            try Task.checkCancellation()
+            return try prepare(data: data, maxPixel: key.maxPixel)
+        }
+
+        let disk = diskURL(for: key.url, in: diskDirectory)
+        if let data = try? Data(contentsOf: disk), !data.isEmpty,
+           let prepared = try? prepare(data: data, maxPixel: key.maxPixel) {
+            try Task.checkCancellation()
+            return prepared
+        }
+
+        let (data, response) = try await session.data(for: URLRequest(url: key.url))
+        try Task.checkCancellation()
+        let ok = (response as? HTTPURLResponse).map {
+            (200..<300).contains($0.statusCode)
+        } ?? true
+        guard ok else { throw LoadError.invalidResponse }
+        guard !data.isEmpty else { throw LoadError.invalidData }
+
+        try? data.write(to: disk, options: .atomic)
+        try Task.checkCancellation()
+        return try prepare(data: data, maxPixel: key.maxPixel)
+    }
+
+    private static func prepare(data: Data, maxPixel: Int) throws -> PreparedImage {
+        guard !data.isEmpty, let image = downsample(data, maxPixel: maxPixel) else {
+            throw LoadError.invalidData
+        }
+        return PreparedImage(
+            image: image,
+            animationData: safeAnimationData(data),
+            sourceData: data
+        )
     }
 
     private func store(data: Data, image: NSImage, dataKey: NSString,
@@ -267,6 +394,13 @@ final class WorkshopImageLoader {
 }
 
 struct WorkshopImage: View {
+    private struct RequestIdentity: Hashable {
+        let url: URL?
+        let maxPixel: Int
+        let hasUsableSize: Bool
+        let isLoadingEnabled: Bool
+    }
+
     let url: URL?
     var contentMode: ContentMode = .fill
     var isAnimating = false
@@ -277,8 +411,15 @@ struct WorkshopImage: View {
     @State private var animationData: Data?
     @State private var failed = false
     @State private var boxSize: CGSize = .zero
-    @State private var loadToken: UInt64 = 0
-    @State private var pendingLoad = false
+
+    private var requestIdentity: RequestIdentity {
+        RequestIdentity(
+            url: url,
+            maxPixel: WorkshopImageLoader.maxPixel(for: boxSize, scale: displayScale),
+            hasUsableSize: boxSize.width > 1 && boxSize.height > 1,
+            isLoadingEnabled: isLoadingEnabled
+        )
+    }
 
     var body: some View {
         Rectangle()
@@ -306,21 +447,16 @@ struct WorkshopImage: View {
                 }
             }
             .clipped()
-            .onAppear {
-                load()
-            }
             .background(
                 GeometryReader { proxy in
                     Color.clear
                         .onAppear {
                             boxSize = proxy.size
-                            load()
                         }
                         .onChange(of: proxy.size) { _, newValue in
                             guard abs(newValue.width - boxSize.width) > 1 ||
                                   abs(newValue.height - boxSize.height) > 1 else { return }
                             boxSize = newValue
-                            load()
                         }
                 }
             )
@@ -328,60 +464,40 @@ struct WorkshopImage: View {
                 image = nil
                 animationData = nil
                 failed = false
-                load()
             }
-            .onChange(of: isLoadingEnabled) { _, enabled in
-                if enabled && pendingLoad {
-                    load()
-                }
-            }
-            .onChange(of: isAnimating) { _, animating in
-                if animating {
-                    load()
-                } else {
-                    animationData = nil
-                }
+            .task(id: requestIdentity) {
+                await load(requestIdentity)
             }
             .onDisappear {
-                loadToken &+= 1
                 animationData = nil
-                pendingLoad = isAnimating
             }
     }
 
-    private func load() {
-        guard boxSize.width > 1, boxSize.height > 1 else { return }
-        guard let url else {
+    @MainActor
+    private func load(_ request: RequestIdentity) async {
+        guard request.hasUsableSize, request == requestIdentity else { return }
+        guard let requestedURL = request.url else {
             image = nil
             animationData = nil
             failed = true
-            pendingLoad = false
             return
         }
-        let scale = displayScale
-        if let cached = WorkshopImageLoader.shared.cachedImage(url: url, targetSize: boxSize, scale: scale) {
-            image = cached
+        guard request.isLoadingEnabled else { return }
+
+        do {
+            let loaded = try await WorkshopImageLoader.shared.load(
+                url: requestedURL,
+                maxPixel: request.maxPixel
+            )
+            guard !Task.isCancelled, request == requestIdentity else { return }
+            image = loaded.image
+            animationData = loaded.animationData
             failed = false
-            pendingLoad = false
-            if !isAnimating { return }
-        }
-        guard isLoadingEnabled else {
-            pendingLoad = true
+        } catch is CancellationError {
             return
-        }
-        pendingLoad = false
-        loadToken &+= 1
-        let token = loadToken
-        let requestedURL = url
-        WorkshopImageLoader.shared.load(url: requestedURL, targetSize: boxSize, scale: scale) { loaded, animatedData in
-            guard token == loadToken, requestedURL == url else { return }
-            if let loaded {
-                image = loaded
-                animationData = animatedData
-                failed = false
-            } else {
-                failed = true
-            }
+        } catch {
+            guard !Task.isCancelled, request == requestIdentity else { return }
+            failed = true
         }
     }
 }

--- a/Mirage/Mirage Wallpaper/GlobalComponents/WorkshopImage.swift
+++ b/Mirage/Mirage Wallpaper/GlobalComponents/WorkshopImage.swift
@@ -5,458 +5,211 @@
 //
 
 import AppKit
-import CryptoKit
-import ImageIO
 import SwiftUI
 
-actor WorkshopImageLoader {
-    static let shared = WorkshopImageLoader()
-
-    // Images are fully prepared before publication and are never mutated by the loader.
-    struct LoadedImage: @unchecked Sendable {
-        let image: NSImage
-        let animationData: Data?
+@MainActor
+private final class WorkshopImageStaticState: ObservableObject {
+    enum Phase {
+        case loading
+        case success(URL, NSImage)
+        case failure(URL?)
     }
 
-    private struct RequestKey: Hashable, Sendable {
-        let url: URL
-        let maxPixel: Int
+    @Published private(set) var phase: Phase = .loading
+
+    func showLoading() {
+        if case .loading = phase { return }
+        phase = .loading
     }
 
-    private struct PreparedImage: @unchecked Sendable {
-        let image: NSImage
-        let animationData: Data?
-        let sourceData: Data
+    func showLoadingIfFailed(for url: URL) {
+        guard case .failure(let currentURL) = phase, currentURL == url else { return }
+        phase = .loading
     }
 
-    private struct PendingLoad {
-        let generationID: UUID
-        let task: Task<Void, Never>
-        var subscribers: [UUID: CheckedContinuation<LoadedImage, Error>]
-    }
-
-    private enum LoadError: Error {
-        case invalidData
-        case invalidResponse
-    }
-
-    private let memory: NSCache<NSString, NSImage> = {
-        let cache = NSCache<NSString, NSImage>()
-        cache.countLimit = 400
-        cache.totalCostLimit = 160 * 1024 * 1024
-        return cache
-    }()
-
-    private let dataMemory: NSCache<NSString, NSData> = {
-        let cache = NSCache<NSString, NSData>()
-        cache.countLimit = 400
-        cache.totalCostLimit = 160 * 1024 * 1024
-        return cache
-    }()
-
-    private let animatedFlags: NSCache<NSString, NSNumber> = {
-        let cache = NSCache<NSString, NSNumber>()
-        cache.countLimit = 4000
-        return cache
-    }()
-
-    private let session: URLSession
-    private let diskDirectory: URL
-    private var pendingLoads: [RequestKey: PendingLoad] = [:]
-
-    // File I/O and ImageIO are synchronous. Keep them off the cooperative
-    // executor and cap their concurrency independently from URLSession.
-    private static let blockingWorkQueue: OperationQueue = {
-        let queue = OperationQueue()
-        queue.name = "cn.laobamac.Mirage.workshopImage.blocking"
-        queue.qualityOfService = .userInitiated
-        queue.maxConcurrentOperationCount = 4
-        return queue
-    }()
-
-    private static func makeSession() -> URLSession {
-        let configuration = URLSessionConfiguration.default
-        configuration.timeoutIntervalForRequest = 20
-        configuration.timeoutIntervalForResource = 40
-        configuration.httpMaximumConnectionsPerHost = 6
-        return URLSession(configuration: configuration)
-    }
-
-    private static func makeDiskDirectory() -> URL {
-        let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
-            .appending(path: "Mirage/WorkshopImageCache")
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir
-    }
-
-    init(
-        session: URLSession = WorkshopImageLoader.makeSession(),
-        diskDirectory: URL = WorkshopImageLoader.makeDiskDirectory()
-    ) {
-        self.session = session
-        self.diskDirectory = diskDirectory
-    }
-
-    static func maxPixel(for size: CGSize, scale: CGFloat) -> Int {
-        let raw = Double(max(size.width, size.height)) * Double(max(scale, 1))
-        let bucket = (raw / 64).rounded(.up) * 64
-        return max(64, min(Int(bucket), 2048))
-    }
-
-    private func memoryKey(_ url: URL, _ px: Int) -> NSString {
-        "\(url.absoluteString)#\(px)" as NSString
-    }
-
-    private static func diskURL(for url: URL, in diskDirectory: URL) -> URL {
-        let digest = SHA256.hash(data: Data(url.absoluteString.utf8))
-            .map { String(format: "%02x", $0) }.joined()
-        return diskDirectory.appending(path: digest)
-    }
-
-    private func cost(_ image: NSImage) -> Int {
-        guard let rep = image.representations.first else { return 1 }
-        return max(1, rep.pixelsWide * rep.pixelsHigh * 4)
-    }
-
-    private func cachedAnimatedFlag(_ url: URL) -> Bool? {
-        animatedFlags.object(forKey: url.absoluteString as NSString)?.boolValue
-    }
-
-    private func setAnimatedFlag(_ value: Bool, for url: URL) {
-        animatedFlags.setObject(NSNumber(value: value), forKey: url.absoluteString as NSString)
-    }
-
-    func load(url: URL, targetSize: CGSize, scale: CGFloat) async throws -> LoadedImage {
-        try await load(
-            url: url,
-            maxPixel: Self.maxPixel(for: targetSize, scale: scale)
-        )
-    }
-
-    func load(url: URL, maxPixel: Int) async throws -> LoadedImage {
-        try Task.checkCancellation()
-
-        let requestKey = RequestKey(url: url, maxPixel: maxPixel)
-        let imageKey = memoryKey(url, maxPixel)
-        let dataKey = url.absoluteString as NSString
-        if let image = memory.object(forKey: imageKey),
-           let animated = cachedAnimatedFlag(url) {
-            guard animated else {
-                return LoadedImage(image: image, animationData: nil)
-            }
-            if let cachedData = dataMemory.object(forKey: dataKey) {
-                return LoadedImage(image: image, animationData: cachedData as Data)
-            }
-        }
-
-        let subscriberID = UUID()
-        let loaded = try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                subscribe(
-                    subscriberID: subscriberID,
-                    to: requestKey,
-                    continuation: continuation
-                )
-            }
-        } onCancel: {
-            Task {
-                await self.cancelSubscriber(subscriberID, from: requestKey)
-            }
-        }
-        try Task.checkCancellation()
-        return loaded
-    }
-
-    private func subscribe(
-        subscriberID: UUID,
-        to key: RequestKey,
-        continuation: CheckedContinuation<LoadedImage, Error>
-    ) {
-        if var pending = pendingLoads[key] {
-            pending.subscribers[subscriberID] = continuation
-            pendingLoads[key] = pending
+    func show(_ image: NSImage, for url: URL) {
+        if case .success(let currentURL, let currentImage) = phase,
+           currentURL == url, currentImage === image {
             return
         }
-
-        let requestID = UUID()
-        let session = session
-        let diskDirectory = diskDirectory
-        let task = Task.detached(priority: .userInitiated) {
-            let result: Result<PreparedImage, Error>
-            do {
-                let prepared = try await Self.fetch(
-                    key: key,
-                    session: session,
-                    diskDirectory: diskDirectory
-                )
-                result = .success(prepared)
-            } catch {
-                result = .failure(error)
-            }
-            await self.finish(key: key, requestID: requestID, result: result)
-        }
-        pendingLoads[key] = PendingLoad(
-            generationID: requestID,
-            task: task,
-            subscribers: [subscriberID: continuation]
-        )
+        phase = .success(url, image)
     }
 
-    private func cancelSubscriber(_ subscriberID: UUID, from key: RequestKey) {
-        guard var pending = pendingLoads[key],
-              let continuation = pending.subscribers.removeValue(forKey: subscriberID) else {
-            return
-        }
+    func showFailure(for url: URL?) {
+        if case .success(let currentURL, _) = phase, currentURL == url { return }
+        if case .failure(let currentURL) = phase, currentURL == url { return }
+        phase = .failure(url)
+    }
+}
 
-        continuation.resume(throwing: CancellationError())
-        if pending.subscribers.isEmpty {
-            pendingLoads.removeValue(forKey: key)
-            pending.task.cancel()
+@MainActor
+private final class WorkshopImageAnimationState: ObservableObject {
+    struct Snapshot {
+        let descriptor: WorkshopImageAnimationDescriptor?
+        let payload: WorkshopImageAnimation?
+    }
+
+    @Published private(set) var snapshot = Snapshot(
+        descriptor: nil,
+        payload: nil
+    )
+
+    func setDescriptor(_ descriptor: WorkshopImageAnimationDescriptor?) {
+        if snapshot.descriptor?.identity != descriptor?.identity {
+            publish(descriptor: descriptor, payload: nil)
         } else {
-            pendingLoads[key] = pending
+            publish(descriptor: descriptor, payload: snapshot.payload)
         }
     }
 
-    private func finish(
-        key: RequestKey,
-        requestID: UUID,
-        result: Result<PreparedImage, Error>
+    func show(
+        _ payload: WorkshopImageAnimation,
+        for descriptor: WorkshopImageAnimationDescriptor
     ) {
-        // Cache a completed success even when cancellation removed the last
-        // subscriber before this actor turn. Generation matching only guards
-        // continuation fan-out, not cache publication.
-        if case .success(let prepared) = result {
-            let animated = prepared.animationData != nil
-            setAnimatedFlag(animated, for: key.url)
-            store(
-                data: prepared.sourceData,
-                image: prepared.image,
-                dataKey: key.url.absoluteString as NSString,
-                imageKey: memoryKey(key.url, key.maxPixel),
-                animated: animated
-            )
-        }
-
-        // A fully cancelled generation may have been replaced for the same key.
-        guard let pending = pendingLoads[key],
-              pending.generationID == requestID else { return }
-        pendingLoads.removeValue(forKey: key)
-
-        let subscriberResult: Result<LoadedImage, Error>
-        switch result {
-        case .success(let prepared):
-            subscriberResult = .success(
-                LoadedImage(image: prepared.image, animationData: prepared.animationData)
-            )
-        case .failure(let error):
-            subscriberResult = .failure(error)
-        }
-
-        for continuation in pending.subscribers.values {
-            continuation.resume(with: subscriberResult)
-        }
+        guard snapshot.descriptor?.identity == descriptor.identity,
+              payload.identity == descriptor.identity else { return }
+        publish(descriptor: descriptor, payload: payload)
     }
 
-    private static func fetch(
-        key: RequestKey,
-        session: URLSession,
-        diskDirectory: URL
-    ) async throws -> PreparedImage {
-        try Task.checkCancellation()
+    func hidePayload() {
+        publish(descriptor: snapshot.descriptor, payload: nil)
+    }
 
-        if key.url.isFileURL {
-            let data = try await performBlocking {
-                try Data(contentsOf: key.url, options: .mappedIfSafe)
-            }
+    func fail(_ descriptor: WorkshopImageAnimationDescriptor) {
+        guard snapshot.descriptor?.identity == descriptor.identity else { return }
+        hidePayload()
+    }
+
+    func reset() {
+        publish(descriptor: nil, payload: nil)
+    }
+
+    private func publish(
+        descriptor: WorkshopImageAnimationDescriptor?,
+        payload: WorkshopImageAnimation?
+    ) {
+        guard snapshot.descriptor != descriptor || snapshot.payload != payload else { return }
+        snapshot = Snapshot(descriptor: descriptor, payload: payload)
+    }
+}
+
+@MainActor
+private final class WorkshopImageController: ObservableObject {
+    struct ImageRequest: Equatable {
+        let url: URL?
+        let maxPixel: Int
+        let isSizeReady: Bool
+        let isLoadingEnabled: Bool
+    }
+
+    struct AnimationRequest: Equatable {
+        let expectedURL: URL?
+        let descriptor: WorkshopImageAnimationDescriptor?
+        let isAnimating: Bool
+        let isLoadingEnabled: Bool
+    }
+
+    let staticState = WorkshopImageStaticState()
+    let animationState = WorkshopImageAnimationState()
+
+    private let loader: WorkshopImageLoader
+    private var sourceURL: URL?
+
+    init(loader: WorkshopImageLoader = WorkshopImageLoader.shared) {
+        self.loader = loader
+    }
+
+    func loadImage(_ request: ImageRequest) async {
+        guard !Task.isCancelled else { return }
+
+        if sourceURL != request.url {
+            sourceURL = request.url
+            staticState.showLoading()
+            animationState.reset()
+        }
+
+        guard request.isSizeReady else { return }
+        guard request.isLoadingEnabled else {
+            animationState.reset()
+            return
+        }
+        guard let url = request.url else {
+            staticState.showFailure(for: nil)
+            animationState.reset()
+            return
+        }
+
+        staticState.showLoadingIfFailed(for: url)
+        do {
+            let loaded = try await loader.load(url: url, maxPixel: request.maxPixel)
             try Task.checkCancellation()
-            return try await performBlocking {
-                try prepare(data: data, maxPixel: key.maxPixel)
-            }
+            guard sourceURL == url else { return }
+            staticState.show(loaded.image, for: url)
+            animationState.setDescriptor(loaded.animationDescriptor)
+        } catch is CancellationError {
+            return
+        } catch {
+            guard !Task.isCancelled, sourceURL == url else { return }
+            staticState.showFailure(for: url)
+            animationState.reset()
         }
+    }
 
-        let disk = diskURL(for: key.url, in: diskDirectory)
-        if let prepared = try? await performBlocking({
-            guard let data = try? Data(contentsOf: disk), !data.isEmpty else {
-                throw LoadError.invalidData
-            }
-            return try prepare(data: data, maxPixel: key.maxPixel)
-        }) {
+    func loadAnimation(_ request: AnimationRequest) async {
+        guard !Task.isCancelled else { return }
+
+        guard request.isLoadingEnabled else {
+            animationState.reset()
+            return
+        }
+        guard request.isAnimating else {
+            animationState.hidePayload()
+            return
+        }
+        guard let expectedURL = request.expectedURL,
+              sourceURL == expectedURL,
+              let descriptor = request.descriptor,
+              descriptor.url == expectedURL,
+              animationState.snapshot.descriptor?.identity == descriptor.identity else {
+            animationState.reset()
+            return
+        }
+        do {
+            let payload = try await loader.loadAnimation(descriptor)
             try Task.checkCancellation()
-            return prepared
-        }
-
-        let (data, response) = try await session.data(for: URLRequest(url: key.url))
-        try Task.checkCancellation()
-        let ok = (response as? HTTPURLResponse).map {
-            (200..<300).contains($0.statusCode)
-        } ?? true
-        guard ok else { throw LoadError.invalidResponse }
-        guard !data.isEmpty else { throw LoadError.invalidData }
-
-        try Task.checkCancellation()
-        return try await performBlocking {
-            try? data.write(to: disk, options: .atomic)
-            return try prepare(data: data, maxPixel: key.maxPixel)
-        }
-    }
-
-    private static func performBlocking<T>(
-        _ work: @escaping () throws -> T
-    ) async throws -> T {
-        try await withCheckedThrowingContinuation { continuation in
-            blockingWorkQueue.addOperation {
-                do {
-                    continuation.resume(returning: try work())
-                } catch {
-                    continuation.resume(throwing: error)
-                }
+            guard sourceURL == expectedURL,
+                  animationState.snapshot.descriptor?.identity == descriptor.identity else {
+                return
             }
+            animationState.show(payload, for: descriptor)
+        } catch is CancellationError {
+            return
+        } catch {
+            guard !Task.isCancelled else { return }
+            animationState.fail(descriptor)
         }
     }
 
-    private static func prepare(data: Data, maxPixel: Int) throws -> PreparedImage {
-        guard !data.isEmpty, let image = downsample(data, maxPixel: maxPixel) else {
-            throw LoadError.invalidData
-        }
-        return PreparedImage(
-            image: image,
-            animationData: safeAnimationData(data),
-            sourceData: data
-        )
-    }
-
-    private func store(data: Data, image: NSImage, dataKey: NSString,
-                       imageKey: NSString, animated: Bool) {
-        if animated {
-            dataMemory.setObject(data as NSData, forKey: dataKey, cost: data.count)
-        }
-        memory.setObject(image, forKey: imageKey, cost: cost(image))
-    }
-
-    private static func safeAnimationData(_ data: Data) -> Data? {
-        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
-        let frameCount = CGImageSourceGetCount(source)
-        guard frameCount > 1,
-              let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
-              let width = (properties[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue,
-              let height = (properties[kCGImagePropertyPixelHeight] as? NSNumber)?.intValue,
-              width > 0, height > 0 else { return nil }
-        let (pixels, pixelOverflow) = width.multipliedReportingOverflow(by: height)
-        let (framePixels, frameOverflow) = pixels.multipliedReportingOverflow(by: frameCount)
-        let (decodedBytes, byteOverflow) = framePixels.multipliedReportingOverflow(by: 4)
-        guard !pixelOverflow, !frameOverflow, !byteOverflow,
-              decodedBytes <= 64 * 1024 * 1024 else { return nil }
-        return data
-    }
-
-    private static func downsample(_ data: Data, maxPixel: Int) -> NSImage? {
-        let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
-        guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else {
-            return NSImage(data: data)
-        }
-        let frameIndex = representativeFrameIndex(in: source)
-        let options: [CFString: Any] = [
-            kCGImageSourceCreateThumbnailFromImageAlways: true,
-            kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceShouldCacheImmediately: true,
-            kCGImageSourceThumbnailMaxPixelSize: maxPixel
-        ]
-        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, frameIndex, options as CFDictionary) else {
-            return NSImage(data: data)
-        }
-        return NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
-    }
-
-    private static func representativeFrameIndex(in source: CGImageSource) -> Int {
-        let count = CGImageSourceGetCount(source)
-        guard count > 1 else { return 0 }
-
-        let sampleCount = min(count, 6)
-        let indexes = Set((0..<sampleCount).map { sample in
-            sampleCount == 1 ? 0 : sample * (count - 1) / (sampleCount - 1)
-        }).sorted()
-        let options: [CFString: Any] = [
-            kCGImageSourceCreateThumbnailFromImageAlways: true,
-            kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceShouldCacheImmediately: true,
-            kCGImageSourceThumbnailMaxPixelSize: 64
-        ]
-
-        for index in indexes {
-            guard let frame = CGImageSourceCreateThumbnailAtIndex(source, index, options as CFDictionary) else {
-                continue
-            }
-            if !isNearBlack(frame) {
-                return index
-            }
-        }
-        return 0
-    }
-
-    private static func isNearBlack(_ image: CGImage) -> Bool {
-        let width = min(image.width, 64)
-        let height = min(image.height, 64)
-        guard width > 0, height > 0 else { return true }
-
-        var pixels = [UInt8](repeating: 0, count: width * height * 4)
-        let rendered = pixels.withUnsafeMutableBytes { bytes -> Bool in
-            guard let context = CGContext(
-                data: bytes.baseAddress,
-                width: width,
-                height: height,
-                bitsPerComponent: 8,
-                bytesPerRow: width * 4,
-                space: CGColorSpaceCreateDeviceRGB(),
-                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-                    | CGBitmapInfo.byteOrder32Big.rawValue
-            ) else { return false }
-            context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
-            return true
-        }
-        guard rendered else { return true }
-
-        var visiblePixels = 0
-        var litPixels = 0
-        var brightnessTotal = 0
-        for offset in stride(from: 0, to: pixels.count, by: 4) {
-            guard pixels[offset + 3] > 8 else { continue }
-            visiblePixels += 1
-            let brightness = max(pixels[offset], pixels[offset + 1], pixels[offset + 2])
-            brightnessTotal += Int(brightness)
-            if brightness > 18 {
-                litPixels += 1
-            }
-        }
-        guard visiblePixels > 0 else { return true }
-        return litPixels * 50 < visiblePixels && brightnessTotal < visiblePixels * 10
+    func disappear() {
+        animationState.reset()
     }
 }
 
 struct WorkshopImage: View {
-    private struct RequestIdentity: Hashable {
-        let url: URL?
-        let maxPixel: Int
-        let hasUsableSize: Bool
-        let isLoadingEnabled: Bool
-    }
-
     let url: URL?
     var contentMode: ContentMode = .fill
     var isAnimating = false
     var isLoadingEnabled = true
 
     @Environment(\.displayScale) private var displayScale
-    @State private var image: NSImage?
-    @State private var animationData: Data?
-    @State private var failed = false
-    @State private var boxSize: CGSize = .zero
+    @StateObject private var controller = WorkshopImageController()
+    @State private var sizing = WorkshopImageSizing.pending
 
-    private var requestIdentity: RequestIdentity {
-        RequestIdentity(
+    private var imageRequest: WorkshopImageController.ImageRequest {
+        WorkshopImageController.ImageRequest(
             url: url,
-            maxPixel: WorkshopImageLoader.maxPixel(for: boxSize, scale: displayScale),
-            hasUsableSize: boxSize.width > 1 && boxSize.height > 1,
+            maxPixel: sizing.maxPixel,
+            isSizeReady: sizing.isSizeReady,
             isLoadingEnabled: isLoadingEnabled
         )
     }
@@ -465,85 +218,131 @@ struct WorkshopImage: View {
         Rectangle()
             .fill(Color.secondary.opacity(0.10))
             .overlay {
-                if let image {
-                    Image(nsImage: image)
-                        .resizable()
-                        .interpolation(.high)
-                        .aspectRatio(contentMode: contentMode)
-                    if isAnimating, let animationData, let url {
-                        WorkshopAnimatedImage(
-                            data: animationData,
-                            identity: url.absoluteString,
-                            contentMode: contentMode
-                        )
-                    }
-                } else if failed {
-                    Image(systemName: "photo")
-                        .font(.title2)
-                        .foregroundStyle(.tertiary)
-                } else {
-                    ProgressView()
-                        .controlSize(.small)
+                ZStack {
+                    WorkshopImageStaticLayer(
+                        state: controller.staticState,
+                        expectedURL: url,
+                        contentMode: contentMode
+                    )
+                    WorkshopImageAnimationLayer(
+                        controller: controller,
+                        state: controller.animationState,
+                        expectedURL: url,
+                        contentMode: contentMode,
+                        isAnimating: isAnimating,
+                        isLoadingEnabled: isLoadingEnabled
+                    )
                 }
             }
             .clipped()
-            .background(
-                GeometryReader { proxy in
-                    Color.clear
-                        .onAppear {
-                            boxSize = proxy.size
-                        }
-                        .onChange(of: proxy.size) { _, newValue in
-                            guard abs(newValue.width - boxSize.width) > 1 ||
-                                  abs(newValue.height - boxSize.height) > 1 else { return }
-                            boxSize = newValue
-                        }
-                }
-            )
-            .onChange(of: url) { _, _ in
-                image = nil
-                animationData = nil
-                failed = false
+            .background {
+                WorkshopImageSizeReader(sizing: $sizing, scale: displayScale)
             }
-            .task(id: requestIdentity) {
-                await load(requestIdentity)
+            .task(id: imageRequest) {
+                await controller.loadImage(imageRequest)
             }
             .onDisappear {
-                animationData = nil
+                controller.disappear()
             }
     }
+}
 
-    @MainActor
-    private func load(_ request: RequestIdentity) async {
-        guard request.hasUsableSize, request == requestIdentity else { return }
-        guard let requestedURL = request.url else {
-            image = nil
-            animationData = nil
-            failed = true
-            return
+private struct WorkshopImageStaticLayer: View {
+    @ObservedObject var state: WorkshopImageStaticState
+    let expectedURL: URL?
+    let contentMode: ContentMode
+
+    var body: some View {
+        switch state.phase {
+        case .loading:
+            ProgressView()
+                .controlSize(.small)
+        case .success(let url, let image) where url == expectedURL:
+            Image(nsImage: image)
+                .resizable()
+                .interpolation(.high)
+                .aspectRatio(contentMode: contentMode)
+        case .failure(let url) where url == expectedURL:
+            Image(systemName: "photo")
+                .font(.title2)
+                .foregroundStyle(.tertiary)
+        default:
+            ProgressView()
+                .controlSize(.small)
         }
-        guard request.isLoadingEnabled else { return }
+    }
+}
 
-        do {
-            let loaded = try await WorkshopImageLoader.shared.load(
-                url: requestedURL,
-                maxPixel: request.maxPixel
-            )
-            guard !Task.isCancelled, request == requestIdentity else { return }
-            image = loaded.image
-            animationData = loaded.animationData
-            failed = false
-        } catch is CancellationError {
-            return
-        } catch {
-            guard !Task.isCancelled, request == requestIdentity else { return }
-            failed = true
+private struct WorkshopImageAnimationLayer: View {
+    let controller: WorkshopImageController
+    @ObservedObject var state: WorkshopImageAnimationState
+    let expectedURL: URL?
+    let contentMode: ContentMode
+    let isAnimating: Bool
+    let isLoadingEnabled: Bool
+
+    private var request: WorkshopImageController.AnimationRequest {
+        WorkshopImageController.AnimationRequest(
+            expectedURL: expectedURL,
+            descriptor: isAnimating && isLoadingEnabled ? state.snapshot.descriptor : nil,
+            isAnimating: isAnimating,
+            isLoadingEnabled: isLoadingEnabled
+        )
+    }
+
+    var body: some View {
+        Group {
+            if isLoadingEnabled, isAnimating,
+               state.snapshot.descriptor?.url == expectedURL,
+               let payload = state.snapshot.payload {
+                WorkshopAnimatedImage(
+                    image: payload.image,
+                    identity: payload.identity,
+                    contentMode: contentMode
+                )
+            }
+        }
+        .task(id: request) {
+            await controller.loadAnimation(request)
+        }
+    }
+}
+
+private struct WorkshopImageSizing: Equatable {
+    static let pending = WorkshopImageSizing(maxPixel: 64, isSizeReady: false)
+
+    let maxPixel: Int
+    let isSizeReady: Bool
+
+    init(size: CGSize, scale: CGFloat) {
+        maxPixel = WorkshopImageLoader.maxPixel(for: size, scale: scale)
+        isSizeReady = size.width > 1 && size.height > 1
+    }
+
+    private init(maxPixel: Int, isSizeReady: Bool) {
+        self.maxPixel = maxPixel
+        self.isSizeReady = isSizeReady
+    }
+}
+
+private struct WorkshopImageSizeReader: View {
+    @Binding var sizing: WorkshopImageSizing
+    let scale: CGFloat
+
+    var body: some View {
+        GeometryReader { proxy in
+            let newSizing = WorkshopImageSizing(size: proxy.size, scale: scale)
+            Color.clear
+                .task(id: newSizing) {
+                    guard !Task.isCancelled, sizing != newSizing else { return }
+                    sizing = newSizing
+                }
         }
     }
 }
 
 private struct WorkshopAnimatedImage: NSViewRepresentable {
-    let data: Data
+    let image: NSImage
     let identity: String
     let contentMode: ContentMode
 
@@ -565,7 +364,7 @@ private struct WorkshopAnimatedImage: NSViewRepresentable {
         view.contentMode = contentMode
         if context.coordinator.identity != identity {
             context.coordinator.identity = identity
-            view.image = NSImage(data: data)
+            view.image = image
         }
     }
 

--- a/Mirage/Mirage Wallpaper/GlobalComponents/WorkshopImage.swift
+++ b/Mirage/Mirage Wallpaper/GlobalComponents/WorkshopImage.swift
@@ -64,6 +64,16 @@ actor WorkshopImageLoader {
     private let diskDirectory: URL
     private var pendingLoads: [RequestKey: PendingLoad] = [:]
 
+    // File I/O and ImageIO are synchronous. Keep them off the cooperative
+    // executor and cap their concurrency independently from URLSession.
+    private static let blockingWorkQueue: OperationQueue = {
+        let queue = OperationQueue()
+        queue.name = "cn.laobamac.Mirage.workshopImage.blocking"
+        queue.qualityOfService = .userInitiated
+        queue.maxConcurrentOperationCount = 4
+        return queue
+    }()
+
     private static func makeSession() -> URLSession {
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = 20
@@ -213,14 +223,10 @@ actor WorkshopImageLoader {
         requestID: UUID,
         result: Result<PreparedImage, Error>
     ) {
-        // A fully cancelled generation may have been replaced for the same key.
-        guard let pending = pendingLoads[key],
-              pending.generationID == requestID else { return }
-        pendingLoads.removeValue(forKey: key)
-
-        let subscriberResult: Result<LoadedImage, Error>
-        switch result {
-        case .success(let prepared):
+        // Cache a completed success even when cancellation removed the last
+        // subscriber before this actor turn. Generation matching only guards
+        // continuation fan-out, not cache publication.
+        if case .success(let prepared) = result {
             let animated = prepared.animationData != nil
             setAnimatedFlag(animated, for: key.url)
             store(
@@ -230,6 +236,16 @@ actor WorkshopImageLoader {
                 imageKey: memoryKey(key.url, key.maxPixel),
                 animated: animated
             )
+        }
+
+        // A fully cancelled generation may have been replaced for the same key.
+        guard let pending = pendingLoads[key],
+              pending.generationID == requestID else { return }
+        pendingLoads.removeValue(forKey: key)
+
+        let subscriberResult: Result<LoadedImage, Error>
+        switch result {
+        case .success(let prepared):
             subscriberResult = .success(
                 LoadedImage(image: prepared.image, animationData: prepared.animationData)
             )
@@ -250,14 +266,22 @@ actor WorkshopImageLoader {
         try Task.checkCancellation()
 
         if key.url.isFileURL {
-            let data = try Data(contentsOf: key.url, options: .mappedIfSafe)
+            let data = try await performBlocking {
+                try Data(contentsOf: key.url, options: .mappedIfSafe)
+            }
             try Task.checkCancellation()
-            return try prepare(data: data, maxPixel: key.maxPixel)
+            return try await performBlocking {
+                try prepare(data: data, maxPixel: key.maxPixel)
+            }
         }
 
         let disk = diskURL(for: key.url, in: diskDirectory)
-        if let data = try? Data(contentsOf: disk), !data.isEmpty,
-           let prepared = try? prepare(data: data, maxPixel: key.maxPixel) {
+        if let prepared = try? await performBlocking({
+            guard let data = try? Data(contentsOf: disk), !data.isEmpty else {
+                throw LoadError.invalidData
+            }
+            return try prepare(data: data, maxPixel: key.maxPixel)
+        }) {
             try Task.checkCancellation()
             return prepared
         }
@@ -270,9 +294,25 @@ actor WorkshopImageLoader {
         guard ok else { throw LoadError.invalidResponse }
         guard !data.isEmpty else { throw LoadError.invalidData }
 
-        try? data.write(to: disk, options: .atomic)
         try Task.checkCancellation()
-        return try prepare(data: data, maxPixel: key.maxPixel)
+        return try await performBlocking {
+            try? data.write(to: disk, options: .atomic)
+            return try prepare(data: data, maxPixel: key.maxPixel)
+        }
+    }
+
+    private static func performBlocking<T>(
+        _ work: @escaping () throws -> T
+    ) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            blockingWorkQueue.addOperation {
+                do {
+                    continuation.resume(returning: try work())
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
     }
 
     private static func prepare(data: Data, maxPixel: Int) throws -> PreparedImage {

--- a/Mirage/Mirage Wallpaper/GlobalComponents/WorkshopImageLoader.swift
+++ b/Mirage/Mirage Wallpaper/GlobalComponents/WorkshopImageLoader.swift
@@ -1,0 +1,725 @@
+//
+//  Mirage Wallpaper
+//
+//  Copyright © 2026 王孝慈. All rights reserved.
+//
+
+import AppKit
+import CryptoKit
+import ImageIO
+
+struct WorkshopImageAnimationDescriptor: Hashable, Sendable {
+    let url: URL
+    let sourceVersion: String?
+    let identity: String
+}
+
+struct WorkshopImageAnimation: @unchecked Sendable, Equatable {
+    let image: NSImage
+    let identity: String
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.identity == rhs.identity
+    }
+}
+
+struct WorkshopLoadedImage: @unchecked Sendable {
+    let image: NSImage
+    let animationDescriptor: WorkshopImageAnimationDescriptor?
+}
+
+actor WorkshopImageLoader {
+    static let shared = WorkshopImageLoader()
+
+    private struct SourceKey: Hashable, Sendable {
+        let url: URL
+        let sourceVersion: String?
+    }
+
+    private struct ImageKey: Hashable, Sendable {
+        let source: SourceKey
+        let generation: UUID
+        let maxPixel: Int
+    }
+
+    private struct SourcePayload: @unchecked Sendable {
+        let generation = UUID()
+        let data: Data
+        let analysis: AnimationAnalysis
+        let fallbackImage: NSImage?
+        let animationDescriptor: WorkshopImageAnimationDescriptor?
+        let expiresAt: Date
+    }
+
+    private struct StaticPayload: @unchecked Sendable {
+        let image: NSImage
+        let expiresAt: Date
+    }
+
+    private struct SourceTask: Sendable {
+        let id = UUID()
+        let task: Task<SourcePayload, Error>
+        var waiters: Set<UUID> = []
+    }
+
+    private final class BlockingResultBox<Value: Sendable>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var result: Result<Value, Error>?
+
+        func store(_ result: Result<Value, Error>) {
+            lock.lock()
+            self.result = result
+            lock.unlock()
+        }
+
+        func take() -> Result<Value, Error>? {
+            lock.lock()
+            defer { lock.unlock() }
+            return result
+        }
+    }
+
+    private final class SourceCacheEntry: NSObject {
+        let payload: SourcePayload
+
+        init(_ payload: SourcePayload) {
+            self.payload = payload
+        }
+    }
+
+    private final class StaticCacheEntry: NSObject {
+        let payload: StaticPayload
+
+        init(_ payload: StaticPayload) {
+            self.payload = payload
+        }
+    }
+
+    private enum AnimationAnalysis: Sendable {
+        case invalidSource
+        case staticImage
+        case safe
+        case unsafe
+
+        var isValidSource: Bool {
+            if case .invalidSource = self { return false }
+            return true
+        }
+
+        var shouldSampleFrames: Bool {
+            switch self {
+            case .safe, .unsafe:
+                return true
+            case .invalidSource, .staticImage:
+                return false
+            }
+        }
+    }
+
+    private enum LoadError: Error {
+        case invalidData
+        case invalidResponse
+        case sourceTooLarge
+    }
+
+    private static let maximumSourceBytes = 64 * 1024 * 1024
+    private static let maximumDecodedAnimationBytes = 64 * 1024 * 1024
+    private static let maximumSourcePixels = 256 * 1024 * 1024
+    private static let maximumCacheLifetime: TimeInterval = 6 * 60 * 60
+
+    private let sourceMemory: NSCache<NSString, SourceCacheEntry> = {
+        let cache = NSCache<NSString, SourceCacheEntry>()
+        cache.countLimit = 120
+        cache.totalCostLimit = 160 * 1024 * 1024
+        return cache
+    }()
+
+    private let staticMemory: NSCache<NSString, StaticCacheEntry> = {
+        let cache = NSCache<NSString, StaticCacheEntry>()
+        cache.countLimit = 400
+        cache.totalCostLimit = 160 * 1024 * 1024
+        return cache
+    }()
+
+    private let session: URLSession
+    private var sourceTasks: [SourceKey: SourceTask] = [:]
+
+    // ImageIO and AppKit decoding are synchronous. Keep them off the
+    // cooperative executor and bound their concurrency separately.
+    private static let blockingWorkQueue: OperationQueue = {
+        let queue = OperationQueue()
+        queue.name = "cn.laobamac.Mirage.workshopImage.blocking"
+        queue.qualityOfService = .userInitiated
+        queue.maxConcurrentOperationCount = 4
+        return queue
+    }()
+
+    init(session: URLSession = WorkshopImageLoader.makeSession()) {
+        self.session = session
+    }
+
+    private static func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 20
+        configuration.timeoutIntervalForResource = 40
+        configuration.httpMaximumConnectionsPerHost = 6
+        configuration.urlCache = URLCache(
+            memoryCapacity: 32 * 1024 * 1024,
+            diskCapacity: 256 * 1024 * 1024
+        )
+        return URLSession(configuration: configuration)
+    }
+
+    static func maxPixel(for size: CGSize, scale: CGFloat) -> Int {
+        let dimension = Double(max(size.width, size.height))
+        guard dimension.isFinite, dimension > 0 else { return 64 }
+
+        let requestedScale = Double(scale)
+        let safeScale = requestedScale.isFinite ? max(requestedScale, 1) : 1
+        let raw = dimension * safeScale
+        guard raw.isFinite else { return 2048 }
+
+        let bucket = (raw / 64).rounded(.up) * 64
+        return Int(min(max(bucket, 64), 2048))
+    }
+
+    func load(url: URL, maxPixel: Int) async throws -> WorkshopLoadedImage {
+        try Task.checkCancellation()
+        let sourceVersion = try await Self.sourceVersion(for: url)
+        try Task.checkCancellation()
+
+        let sourceKey = SourceKey(url: url, sourceVersion: sourceVersion)
+        let source = try await loadSource(for: sourceKey)
+        try Task.checkCancellation()
+        let imageKey = ImageKey(
+            source: sourceKey,
+            generation: source.generation,
+            maxPixel: Self.normalizedMaxPixel(maxPixel)
+        )
+        let staticPayload = try await loadStatic(for: imageKey, source: source)
+        try Task.checkCancellation()
+        return WorkshopLoadedImage(
+            image: staticPayload.image,
+            animationDescriptor: source.animationDescriptor
+        )
+    }
+
+    func loadAnimation(
+        _ descriptor: WorkshopImageAnimationDescriptor
+    ) async throws -> WorkshopImageAnimation {
+        try Task.checkCancellation()
+        let sourceKey = SourceKey(
+            url: descriptor.url,
+            sourceVersion: descriptor.sourceVersion
+        )
+        let source = try await loadSource(for: sourceKey)
+        try Task.checkCancellation()
+        guard source.animationDescriptor == descriptor else {
+            throw LoadError.invalidData
+        }
+        return try await loadPreparedAnimation(descriptor, source: source)
+    }
+
+    private func loadSource(for key: SourceKey) async throws -> SourcePayload {
+        let cacheKey = sourceMemoryKey(for: key)
+        if let cached = sourceMemory.object(forKey: cacheKey) {
+            if cached.payload.expiresAt > Date() {
+                return cached.payload
+            }
+            sourceMemory.removeObject(forKey: cacheKey)
+        }
+
+        let waiterID = UUID()
+        let entry: SourceTask
+        if var pending = sourceTasks[key] {
+            pending.waiters.insert(waiterID)
+            sourceTasks[key] = pending
+            entry = pending
+        } else {
+            let session = session
+            let task = Task.detached(priority: .userInitiated) {
+                try await Self.fetchSource(key: key, session: session)
+            }
+            var pending = SourceTask(task: task)
+            pending.waiters.insert(waiterID)
+            sourceTasks[key] = pending
+            entry = pending
+        }
+
+        let result = await withTaskCancellationHandler {
+            await entry.task.result
+        } onCancel: {
+            Task {
+                await self.cancelSourceWaiter(
+                    waiterID,
+                    key: key,
+                    taskID: entry.id
+                )
+            }
+        }
+        if sourceTasks[key]?.id == entry.id {
+            sourceTasks.removeValue(forKey: key)
+            if case .success(let payload) = result, payload.expiresAt > Date() {
+                sourceMemory.setObject(
+                    SourceCacheEntry(payload),
+                    forKey: cacheKey,
+                    cost: sourceCost(payload)
+                )
+            }
+        }
+        try Task.checkCancellation()
+        return try result.get()
+    }
+
+    private func loadStatic(
+        for key: ImageKey,
+        source: SourcePayload
+    ) async throws -> StaticPayload {
+        let cacheKey = staticMemoryKey(for: key)
+        if let cached = staticMemory.object(forKey: cacheKey) {
+            if cached.payload.expiresAt > Date() {
+                return cached.payload
+            }
+            staticMemory.removeObject(forKey: cacheKey)
+        }
+
+        let payload = try await Self.performBlocking {
+            try Self.prepareStatic(source: source, maxPixel: key.maxPixel)
+        }
+        if payload.expiresAt > Date() {
+            staticMemory.setObject(
+                StaticCacheEntry(payload),
+                forKey: cacheKey,
+                cost: imageCost(payload.image)
+            )
+        }
+        try Task.checkCancellation()
+        return payload
+    }
+
+    private func loadPreparedAnimation(
+        _ descriptor: WorkshopImageAnimationDescriptor,
+        source: SourcePayload
+    ) async throws -> WorkshopImageAnimation {
+        try await Self.performBlocking {
+            try Self.prepareAnimation(descriptor: descriptor, source: source)
+        }
+    }
+
+    private func cancelSourceWaiter(
+        _ waiterID: UUID,
+        key: SourceKey,
+        taskID: UUID
+    ) {
+        guard var entry = sourceTasks[key], entry.id == taskID,
+              entry.waiters.remove(waiterID) != nil else { return }
+        if entry.waiters.isEmpty {
+            sourceTasks.removeValue(forKey: key)
+            entry.task.cancel()
+        } else {
+            sourceTasks[key] = entry
+        }
+    }
+
+    private func sourceMemoryKey(for key: SourceKey) -> NSString {
+        "\(key.url.absoluteString)#\(key.sourceVersion ?? "remote")" as NSString
+    }
+
+    private func staticMemoryKey(for key: ImageKey) -> NSString {
+        "\(key.source.url.absoluteString)#\(key.generation)#\(key.maxPixel)" as NSString
+    }
+
+    private func sourceCost(_ payload: SourcePayload) -> Int {
+        payload.data.count + (payload.fallbackImage.map(imageCost) ?? 0)
+    }
+
+    private func imageCost(_ image: NSImage) -> Int {
+        Self.imageCost(image)
+    }
+
+    private static func imageCost(_ image: NSImage) -> Int {
+        guard let representation = image.representations.first else { return 1 }
+        let (pixels, pixelOverflow) = representation.pixelsWide
+            .multipliedReportingOverflow(by: representation.pixelsHigh)
+        let (bytes, byteOverflow) = pixels.multipliedReportingOverflow(by: 4)
+        guard !pixelOverflow, !byteOverflow else { return 1 }
+        return max(1, bytes)
+    }
+
+    private static func normalizedMaxPixel(_ maxPixel: Int) -> Int {
+        let bounded = min(max(maxPixel, 64), 2048)
+        return ((bounded - 1) / 64 + 1) * 64
+    }
+
+    private static func sourceVersion(for url: URL) async throws -> String? {
+        guard url.isFileURL else { return nil }
+        return try await performBlocking {
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+            guard let size = (attributes[.size] as? NSNumber)?.uint64Value else {
+                throw LoadError.invalidData
+            }
+            let modified = (attributes[.modificationDate] as? Date)?
+                .timeIntervalSinceReferenceDate ?? 0
+            let fileNumber = (attributes[.systemFileNumber] as? NSNumber)?.uint64Value ?? 0
+            return "\(size)#\(modified)#\(fileNumber)"
+        }
+    }
+
+    private static func fetchSource(
+        key: SourceKey,
+        session: URLSession
+    ) async throws -> SourcePayload {
+        try Task.checkCancellation()
+        if key.url.isFileURL {
+            return try await performBlocking {
+                let data = try readSourceData(at: key.url)
+                return try prepareSource(
+                    key: key,
+                    data: data,
+                    expiresAt: .distantFuture
+                )
+            }
+        }
+
+        let (data, response) = try await session.data(for: URLRequest(url: key.url))
+        try Task.checkCancellation()
+        try validate(response: response)
+        guard !data.isEmpty else { throw LoadError.invalidData }
+        guard data.count <= maximumSourceBytes else { throw LoadError.sourceTooLarge }
+        let expiresAt = cacheExpiration(for: response)
+        return try await performBlocking {
+            return try prepareSource(key: key, data: data, expiresAt: expiresAt)
+        }
+    }
+
+    private static func readSourceData(at url: URL) throws -> Data {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        guard let size = (attributes[.size] as? NSNumber)?.uint64Value, size > 0 else {
+            throw LoadError.invalidData
+        }
+        guard size <= UInt64(maximumSourceBytes) else {
+            throw LoadError.sourceTooLarge
+        }
+        let data = try Data(contentsOf: url, options: .mappedIfSafe)
+        guard !data.isEmpty else { throw LoadError.invalidData }
+        guard data.count <= maximumSourceBytes else { throw LoadError.sourceTooLarge }
+        return data
+    }
+
+    private static func validate(response: URLResponse) throws {
+        if let response = response as? HTTPURLResponse,
+           !(200..<300).contains(response.statusCode) {
+            throw LoadError.invalidResponse
+        }
+    }
+
+    private static func cacheExpiration(for response: URLResponse) -> Date {
+        let now = Date()
+        guard let response = response as? HTTPURLResponse else {
+            return now.addingTimeInterval(maximumCacheLifetime)
+        }
+
+        let directives = response.value(forHTTPHeaderField: "Cache-Control")?
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            ?? []
+        if directives.contains("no-store") || directives.contains("no-cache") ||
+            response.value(forHTTPHeaderField: "Vary")?.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            ) == "*" ||
+            response.value(forHTTPHeaderField: "Pragma")?.lowercased() == "no-cache" {
+            return .distantPast
+        }
+        if let directive = directives.first(where: { $0.hasPrefix("max-age=") }),
+           let seconds = TimeInterval(directive.dropFirst("max-age=".count)) {
+            let age = TimeInterval(response.value(forHTTPHeaderField: "Age") ?? "") ?? 0
+            let remaining = max(seconds - max(age, 0), 0)
+            return now.addingTimeInterval(min(remaining, maximumCacheLifetime))
+        }
+        if let value = response.value(forHTTPHeaderField: "Expires") {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(secondsFromGMT: 0)
+            formatter.dateFormat = "EEE',' dd MMM yyyy HH':'mm':'ss z"
+            if let expiration = formatter.date(from: value) {
+                return min(expiration, now.addingTimeInterval(maximumCacheLifetime))
+            }
+        }
+        if directives.contains("must-revalidate") {
+            return .distantPast
+        }
+        return now.addingTimeInterval(maximumCacheLifetime)
+    }
+
+    private static func prepareSource(
+        key: SourceKey,
+        data: Data,
+        expiresAt: Date
+    ) throws -> SourcePayload {
+        let analysis = animationAnalysis(data)
+        if analysis.isValidSource {
+            let descriptor: WorkshopImageAnimationDescriptor?
+            if case .safe = analysis {
+                let identity = SHA256.hash(data: data)
+                    .map { String(format: "%02x", $0) }
+                    .joined()
+                descriptor = WorkshopImageAnimationDescriptor(
+                    url: key.url,
+                    sourceVersion: key.sourceVersion,
+                    identity: identity
+                )
+            } else {
+                descriptor = nil
+            }
+            return SourcePayload(
+                data: data,
+                analysis: analysis,
+                fallbackImage: nil,
+                animationDescriptor: descriptor,
+                expiresAt: expiresAt
+            )
+        }
+
+        guard let fallbackImage = appKitFallbackImage(data),
+              isReasonableFallbackImage(fallbackImage) else {
+            throw LoadError.invalidData
+        }
+        return SourcePayload(
+            data: data,
+            analysis: .staticImage,
+            fallbackImage: fallbackImage,
+            animationDescriptor: nil,
+            expiresAt: expiresAt
+        )
+    }
+
+    private static func prepareStatic(
+        source: SourcePayload,
+        maxPixel: Int
+    ) throws -> StaticPayload {
+        guard let image = downsample(
+            source.data,
+            fallbackImage: source.fallbackImage,
+            maxPixel: maxPixel,
+            sampleAnimatedFrames: source.analysis.shouldSampleFrames
+        ) else {
+            throw LoadError.invalidData
+        }
+        return StaticPayload(image: image, expiresAt: source.expiresAt)
+    }
+
+    private static func prepareAnimation(
+        descriptor: WorkshopImageAnimationDescriptor,
+        source: SourcePayload
+    ) throws -> WorkshopImageAnimation {
+        guard let image = NSImage(data: source.data), image.isValid else {
+            throw LoadError.invalidData
+        }
+        return WorkshopImageAnimation(
+            image: image,
+            identity: descriptor.identity
+        )
+    }
+
+    private static func animationAnalysis(_ data: Data) -> AnimationAnalysis {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+            return .invalidSource
+        }
+        let frameCount = CGImageSourceGetCount(source)
+        guard frameCount > 0 else { return .invalidSource }
+
+        let sourceProperties = CGImageSourceCopyProperties(source, nil) as? [CFString: Any]
+        let frameProperties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil)
+            as? [CFString: Any]
+        guard let (width, height) = pixelDimensions(in: sourceProperties)
+                ?? pixelDimensions(in: frameProperties) else {
+            return .invalidSource
+        }
+        let (pixels, pixelOverflow) = width.multipliedReportingOverflow(by: height)
+        guard !pixelOverflow, pixels <= maximumSourcePixels else {
+            return .invalidSource
+        }
+        guard frameCount > 1 else { return .staticImage }
+
+        let (framePixels, frameOverflow) = pixels.multipliedReportingOverflow(by: frameCount)
+        let (decodedBytes, byteOverflow) = framePixels.multipliedReportingOverflow(by: 4)
+        guard !frameOverflow, !byteOverflow,
+              decodedBytes <= maximumDecodedAnimationBytes else {
+            return .unsafe
+        }
+        return .safe
+    }
+
+    private static func pixelDimensions(
+        in properties: [CFString: Any]?
+    ) -> (Int, Int)? {
+        guard let width = (properties?[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue,
+              let height = (properties?[kCGImagePropertyPixelHeight] as? NSNumber)?.intValue,
+              width > 0, height > 0 else { return nil }
+        return (width, height)
+    }
+
+    private static func downsample(
+        _ data: Data,
+        fallbackImage: NSImage?,
+        maxPixel: Int,
+        sampleAnimatedFrames: Bool
+    ) -> NSImage? {
+        let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else {
+            return downsampleFallback(
+                fallbackImage ?? appKitFallbackImage(data),
+                maxPixel: maxPixel
+            )
+        }
+        let frameIndex = sampleAnimatedFrames ? representativeFrameIndex(in: source) : 0
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixel
+        ]
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(
+            source,
+            frameIndex,
+            options as CFDictionary
+        ) else {
+            return downsampleFallback(
+                fallbackImage ?? appKitFallbackImage(data),
+                maxPixel: maxPixel
+            )
+        }
+        return NSImage(
+            cgImage: cgImage,
+            size: NSSize(width: cgImage.width, height: cgImage.height)
+        )
+    }
+
+    private static func appKitFallbackImage(_ data: Data) -> NSImage? {
+        guard let image = NSImage(data: data), image.isValid else { return nil }
+        return image
+    }
+
+    private static func isReasonableFallbackImage(_ image: NSImage) -> Bool {
+        for representation in image.representations {
+            let width = representation.pixelsWide
+            let height = representation.pixelsHigh
+            guard width > 0, height > 0 else { continue }
+            let (pixels, overflow) = width.multipliedReportingOverflow(by: height)
+            return !overflow && pixels <= maximumSourcePixels
+        }
+        return image.size.width > 0 && image.size.height > 0
+    }
+
+    private static func downsampleFallback(_ image: NSImage?, maxPixel: Int) -> NSImage? {
+        guard let image else { return nil }
+        let sourceSize = image.size
+        guard sourceSize.width > 0, sourceSize.height > 0 else { return image }
+
+        let scale = min(
+            1,
+            CGFloat(maxPixel) / max(sourceSize.width, sourceSize.height)
+        )
+        let targetSize = NSSize(
+            width: max(1, sourceSize.width * scale),
+            height: max(1, sourceSize.height * scale)
+        )
+        var proposedRect = NSRect(origin: .zero, size: targetSize)
+        guard let cgImage = image.cgImage(
+            forProposedRect: &proposedRect,
+            context: nil,
+            hints: nil
+        ) else { return image }
+        return NSImage(cgImage: cgImage, size: targetSize)
+    }
+
+    private static func representativeFrameIndex(in source: CGImageSource) -> Int {
+        let count = CGImageSourceGetCount(source)
+        guard count > 1 else { return 0 }
+
+        let sampleCount = min(count, 6)
+        let indexes = Set((0..<sampleCount).map { sample in
+            sampleCount == 1 ? 0 : sample * (count - 1) / (sampleCount - 1)
+        }).sorted()
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: 64
+        ]
+
+        for index in indexes {
+            guard let frame = CGImageSourceCreateThumbnailAtIndex(
+                source,
+                index,
+                options as CFDictionary
+            ) else { continue }
+            if !isNearBlack(frame) {
+                return index
+            }
+        }
+        return 0
+    }
+
+    private static func performBlocking<T: Sendable>(
+        _ work: @escaping @Sendable () throws -> T
+    ) async throws -> T {
+        try Task.checkCancellation()
+        let result = BlockingResultBox<T>()
+        let operation = BlockOperation {
+            result.store(Result { try work() })
+        }
+        let value: T = try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                operation.completionBlock = {
+                    continuation.resume(
+                        with: result.take() ?? .failure(CancellationError())
+                    )
+                }
+                blockingWorkQueue.addOperation(operation)
+            }
+        } onCancel: {
+            operation.cancel()
+        }
+        try Task.checkCancellation()
+        return value
+    }
+
+    private static func isNearBlack(_ image: CGImage) -> Bool {
+        let width = min(image.width, 64)
+        let height = min(image.height, 64)
+        guard width > 0, height > 0 else { return true }
+
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        let rendered = pixels.withUnsafeMutableBytes { bytes -> Bool in
+            guard let context = CGContext(
+                data: bytes.baseAddress,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                    | CGBitmapInfo.byteOrder32Big.rawValue
+            ) else { return false }
+            context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+            return true
+        }
+        guard rendered else { return true }
+
+        var visiblePixels = 0
+        var litPixels = 0
+        var brightnessTotal = 0
+        for offset in stride(from: 0, to: pixels.count, by: 4) {
+            guard pixels[offset + 3] > 8 else { continue }
+            visiblePixels += 1
+            let brightness = max(pixels[offset], pixels[offset + 1], pixels[offset + 2])
+            brightnessTotal += Int(brightness)
+            if brightness > 18 {
+                litPixels += 1
+            }
+        }
+        guard visiblePixels > 0 else { return true }
+        return litPixels * 50 < visiblePixels && brightnessTotal < visiblePixels * 10
+    }
+}


### PR DESCRIPTION
Replace the legacy WorkshopImageLoader class with a concurrency-safe actor and migrate image loading to async/await. Changes include: actor-based loader state, deduplicated pending loads, cancellation-aware subscribers, disk and memory caching, request hashing, downsampling/prepare pipeline, and file-URL handling. WorkshopImage view updated to use a RequestIdentity and .task(id:) to drive async loads and to handle results/cancellation. Removes the old callback-based API and IO queue/semaphore. This makes loading safe across threads, reduces duplicate network work, and improves cancellation behavior.

支持异步请求合并与生命周期取消