### PR TITLE
修复网站卡片不对齐的问题、修复 header 中不应该存在的 bottom 边框、为 website 子项目添加 biome

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,11 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "check": "astro check"
+    "check": "astro check",
+    "lint": "biome check --write ./src",
+    "biome:check": "biome check ./src",
+    "biome:format": "biome format ./src",
+    "format": "biome format --write ./src"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.3",
@@ -20,6 +24,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
+    "@biomejs/biome": "^2.5.12",
     "typescript": "^5.9.3"
   }
 }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.9
         version: 0.9.9(prettier@3.9.5)(typescript@5.9.3)
+      '@biomejs/biome':
+        specifier: ^2.5.12
+        version: 2.5.12
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -174,6 +177,63 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@biomejs/biome@2.5.12':
+    resolution: {integrity: sha512-Lw4VHZRebrReBBnlHa12JQjnIBm3JJAA55PDB9LbBVBF0q4RYphm6KfmIjqtPhf61MxZ5Q9KoK8R8x+7per5Aw==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.5.12':
+    resolution: {integrity: sha512-lCRY1rwgNeWNgTr4DI/u6ZwXTRwRLHAvbaio1YLLGS+4r1nhvB2ssyPqIpfUSmRveNfv0fn/N58C7CAdK2XVrg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.5.12':
+    resolution: {integrity: sha512-vhPgwnh+6tN3ArdAXuET99xaNbFt7CG82Bqn+omHVLC5xdVx45JsYjGPmUIGNzjDek5XdNCP1HKksK7fn8+3bQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.5.12':
+    resolution: {integrity: sha512-couHYjFLL5uuI8ne6zhT7KwEsXo5YP7ry/2xmEqah7qanu0YmfDi3mwJg47YXSuv/NpZj22CZzcRH/5c4gjPSQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.5.12':
+    resolution: {integrity: sha512-2gp8aVwXYKdAtmBfRFCUuyDMcfN1ahHqUkGfLYrZlNRFmryMATLVvJgWKvyA8wu4Rwn5OSxM1UcUmOuOFNGeBQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.5.12':
+    resolution: {integrity: sha512-8A0oDW58/w9f/PQNYuq0sGUZtGtGrkNF4Z6n0PUoXpLCshi85vtKTv1XSznQawhdE4MXJ8ufpzHXyLFe87M/+w==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.5.12':
+    resolution: {integrity: sha512-SnvOs3TSTiuia4SQOUNe1aWC9RT4+YkjcKnOhL/nsKOV0k5ycgBkDzF0lUxKn1V7Q8CLTRq6iV23ZAivHomRoA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.5.12':
+    resolution: {integrity: sha512-b9vtoZFsuZt1pdjNwJvXl0f+BpayRzV008uS2+JpmwIKdSE2qdu4A/l04FESwLoou5g2E/Qlec0xwJydZplH+A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.5.12':
+    resolution: {integrity: sha512-B1R/l+CwEpKFSuqiwePzPNRk1EiJN8kc0UhdafNz6MZN9v5OFP9HYP1irptvWzHrwVI4blVNGMbxc5zt70m3IA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@bruits/satteri-darwin-arm64@0.9.5':
     resolution: {integrity: sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow==}
@@ -548,6 +608,7 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
@@ -2512,6 +2573,41 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@biomejs/biome@2.5.12':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.5.12
+      '@biomejs/cli-darwin-x64': 2.5.12
+      '@biomejs/cli-linux-arm64': 2.5.12
+      '@biomejs/cli-linux-arm64-musl': 2.5.12
+      '@biomejs/cli-linux-x64': 2.5.12
+      '@biomejs/cli-linux-x64-musl': 2.5.12
+      '@biomejs/cli-win32-arm64': 2.5.12
+      '@biomejs/cli-win32-x64': 2.5.12
+
+  '@biomejs/cli-darwin-arm64@2.5.12':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.5.12':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.5.12':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.5.12':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.5.12':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.5.12':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.5.12':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.5.12':
+    optional: true
 
   '@bruits/satteri-darwin-arm64@0.9.5':
     optional: true

--- a/website/src/components/Landing.astro
+++ b/website/src/components/Landing.astro
@@ -1,66 +1,190 @@
 ---
-interface Props { lang?: 'zh' | 'en' }
-const { lang = 'zh' } = Astro.props;
-const isEnglish = lang === 'en';
-const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+interface Props {
+	lang?: "zh" | "en";
+}
+const { lang = "zh" } = Astro.props;
+const isEnglish = lang === "en";
+const base = import.meta.env.BASE_URL.replace(/\/$/, "");
 const local = (path: string) => `${base}${path}`;
-const github = 'https://github.com/laobamac/MirageWallpaper';
+const github = "https://github.com/laobamac/MirageWallpaper";
 const releases = `${github}/releases`;
-const docs = isEnglish ? local('/en/guides/introduction/') : local('/guides/introduction/');
-const support = isEnglish ? local('/en/reference/support/') : local('/reference/support/');
+const docs = isEnglish
+	? local("/en/guides/introduction/")
+	: local("/guides/introduction/");
+const support = isEnglish
+	? local("/en/reference/support/")
+	: local("/reference/support/");
 
-const t = isEnglish ? {
-  badge: 'Native live wallpaper for macOS',
-  heroLine1: 'Your live wallpapers,', heroLine2: 'awake on Mac.',
-  heroText: 'Scene, web, and video wallpapers. Steam Workshop, per-display control, smart playback rules, and a standalone live screen saver — together in one native macOS app.',
-  getStarted: 'Get Mirage', readDocs: 'Read the docs',
-  heroAlt: 'A live scene wallpaper rendered by Mirage on macOS',
-  heroCaption: 'A real scene wallpaper rendered by Mirage', heroMeta: 'Live output · Scene renderer',
-  formatsEyebrow: 'Three formats, one library', formatsTitle: 'Use the wallpapers you already love.',
-  formats: [
-    { name: 'SCENE', title: 'Rendered worlds', text: 'Materials, particles, lighting, effects, and user properties rendered through Vulkan and MoltenVK.', image: '/images/product/format-scene.webp', alt: 'A scene wallpaper rendered by Mirage' },
-    { name: 'WEB', title: 'Interactive canvases', text: 'HTML, JavaScript, media, mouse interaction, and audio response hosted by WKWebView.', image: '/images/product/format-web.webp', alt: 'A real web audio visualizer wallpaper in Mirage' },
-    { name: 'VIDEO', title: 'Effortless motion', text: 'Smooth looping, speed, volume, and fill modes for local video wallpapers through AVFoundation.', image: '/images/product/format-video.webp', alt: 'A real 4K 120 FPS video wallpaper in Mirage' },
-  ],
-  libraryEyebrow: 'The real Mirage library', libraryTitle: 'Hundreds of wallpapers. Still easy to manage.',
-  libraryText: 'Search, sort, filter, favourite, import, and tune playback in one native workspace. Local items, Workshop downloads, and presets stay together with their source clearly identified.',
-  libraryPoints: ['Per-display assignment', 'Live playback controls', 'Custom properties', 'Menu-bar control'], libraryAlt: 'The real Mirage installed wallpaper library',
-  workshopEyebrow: 'Steam Workshop', workshopTitle: 'Browse, filter, and download without leaving Mirage.',
-  workshopText: 'Discover Workshop content by format, tag, popularity, rating, and recency. Mirage handles Steam sign-in, Steam Guard, concurrent downloads, live speed, and preset dependencies.', workshopLink: 'Open the Workshop guide', workshopAlt: 'Steam Workshop nature wallpapers inside Mirage',
-  rulesEyebrow: 'Smart playback', rulesTitle: 'Motion that knows when to step back.', rulesText: 'Choose what happens when another app is full screen, audio is playing, the display sleeps, or a MacBook switches to battery power.', rulesLink: 'Performance settings',
-  saverEyebrow: 'Live screen saver', saverTitle: 'Your wallpaper keeps moving when you step away.', saverText: 'Use the same scene, web, or video wallpaper as a standalone screen saver, with its preset and custom properties preserved.', saverLink: 'Screen saver guide',
-  displayEyebrow: 'Per-display control', displayTitle: 'The right wallpaper on the right screen.', displayText: 'See every connected display, apply the selected wallpaper to one screen, or stop individual renderers from a focused control panel.', displayAlt: 'Mirage display assignment panel', displayLink: 'Multi-display guide',
-  openEyebrow: 'Open, transparent, supportable', openTitle: 'Built in the open — and free to use.', openText: 'Mirage is GPL-3.0 software for macOS 14.2 and later. Sponsorship is optional and never unlocks or restricts features.', openAlt: 'Mirage About page with project and sponsorship information', supportLink: 'Support Mirage', sourceLink: 'Browse source',
-  finalTitle: 'Give your desktop another dimension.', finalText: 'Available for Apple Silicon and Intel Macs.', finalPrimary: 'Download Mirage', finalSecondary: 'Start with the docs',
-  disclaimer: 'Mirage is not affiliated with or endorsed by Valve, Steam, or Wallpaper Engine.',
-} : {
-  badge: 'macOS 原生动态壁纸',
-  heroLine1: '让喜欢的动态壁纸，', heroLine2: '在 Mac 上醒来。',
-  heroText: '场景、网页与视频壁纸，Steam 创意工坊、按显示器控制、智能播放策略和独立动态屏保，都在同一个原生 macOS 应用中。',
-  getStarted: '获取 Mirage', readDocs: '阅读文档',
-  heroAlt: 'Mirage 在 macOS 上实际渲染的动态场景壁纸',
-  heroCaption: '由 Mirage 实际渲染的场景壁纸', heroMeta: '实时输出 · Scene 渲染器',
-  formatsEyebrow: '三种格式，一个壁纸库', formatsTitle: '你已经喜欢的壁纸，继续在 Mac 上使用。',
-  formats: [
-    { name: 'SCENE', title: '真正渲染的动态世界', text: '通过 Vulkan 与 MoltenVK 呈现材质、粒子、灯光、特效和作品自定义属性。', image: '/images/product/format-scene.webp', alt: 'Mirage 实际渲染的场景壁纸' },
-    { name: 'WEB', title: '可以交互的网页画布', text: 'WKWebView 承载 HTML、JavaScript、媒体、鼠标交互与音频响应。', image: '/images/product/format-web.webp', alt: 'Mirage 中真实的网页音频可视化壁纸' },
-    { name: 'VIDEO', title: '无需折腾的流动画面', text: 'AVFoundation 负责本地视频壁纸的平滑循环、速度、音量和填充模式。', image: '/images/product/format-video.webp', alt: 'Mirage 中真实的 4K 120 FPS 视频壁纸' },
-  ],
-  libraryEyebrow: '真实的 Mirage 壁纸库', libraryTitle: '几百张壁纸，也依然清楚好用。',
-  libraryText: '搜索、排序、筛选、收藏、导入和播放调节都在同一个原生工作区。本地作品、创意工坊下载和预设集中管理，同时保留清晰来源。',
-  libraryPoints: ['按显示器独立指派', '实时播放控制', '作品自定义属性', '菜单栏快捷控制'], libraryAlt: '真实的 Mirage 已安装壁纸库',
-  workshopEyebrow: 'Steam 创意工坊', workshopTitle: '浏览、筛选、下载，全程不必离开 Mirage。',
-  workshopText: '按格式、标签、热度、评分与时间发现创意工坊内容。Steam 登录、Steam Guard、并发下载、实时速度和预设依赖均由 Mirage 管理。', workshopLink: '打开创意工坊指南', workshopAlt: 'Mirage 中经过自然标签筛选的 Steam 创意工坊',
-  rulesEyebrow: '智能播放策略', rulesTitle: '动态，也知道什么时候应该退场。', rulesText: '为其他应用全屏、播放音频、显示器睡眠和 MacBook 使用电池分别决定继续、静音、暂停或停止。', rulesLink: '查看性能设置',
-  saverEyebrow: '动态屏保', saverTitle: '离开电脑后，壁纸继续流动。', saverText: '同一张场景、网页或视频壁纸可以直接成为独立屏保，并保留当前预设与自定义属性。', saverLink: '查看屏保指南',
-  displayEyebrow: '按显示器控制', displayTitle: '每一块屏幕，都可以有自己的选择。', displayText: '集中查看连接的显示器，把当前壁纸应用到指定屏幕，或单独停止某个渲染器。', displayAlt: 'Mirage 显示器壁纸指派面板', displayLink: '查看多显示器指南',
-  openEyebrow: '开放、透明、可持续', openTitle: '开源构建，也始终免费使用。', openText: 'Mirage 遵循 GPL-3.0，支持 macOS 14.2 及更高版本。赞助完全自愿，不会解锁或限制任何功能。', openAlt: 'Mirage 关于页面中的项目信息和赞助方式', supportLink: '支持 Mirage', sourceLink: '浏览源码',
-  finalTitle: '给桌面，再多一个维度。', finalText: '同时支持 Apple Silicon 与 Intel Mac。', finalPrimary: '下载 Mirage', finalSecondary: '从文档开始',
-  disclaimer: 'Mirage 与 Valve、Steam 或 Wallpaper Engine 没有关联，也未获其官方认可。',
-};
+const t = isEnglish
+	? {
+			badge: "Native live wallpaper for macOS",
+			heroLine1: "Your live wallpapers,",
+			heroLine2: "awake on Mac.",
+			heroText:
+				"Scene, web, and video wallpapers. Steam Workshop, per-display control, smart playback rules, and a standalone live screen saver — together in one native macOS app.",
+			getStarted: "Get Mirage",
+			readDocs: "Read the docs",
+			heroAlt: "A live scene wallpaper rendered by Mirage on macOS",
+			heroCaption: "A real scene wallpaper rendered by Mirage",
+			heroMeta: "Live output · Scene renderer",
+			formatsEyebrow: "Three formats, one library",
+			formatsTitle: "Use the wallpapers you already love.",
+			formats: [
+				{
+					name: "SCENE",
+					title: "Rendered worlds",
+					text: "Materials, particles, lighting, effects, and user properties rendered through Vulkan and MoltenVK.",
+					image: "/images/product/format-scene.webp",
+					alt: "A scene wallpaper rendered by Mirage",
+				},
+				{
+					name: "WEB",
+					title: "Interactive canvases",
+					text: "HTML, JavaScript, media, mouse interaction, and audio response hosted by WKWebView.",
+					image: "/images/product/format-web.webp",
+					alt: "A real web audio visualizer wallpaper in Mirage",
+				},
+				{
+					name: "VIDEO",
+					title: "Effortless motion",
+					text: "Smooth looping, speed, volume, and fill modes for local video wallpapers through AVFoundation.",
+					image: "/images/product/format-video.webp",
+					alt: "A real 4K 120 FPS video wallpaper in Mirage",
+				},
+			],
+			libraryEyebrow: "The real Mirage library",
+			libraryTitle: "Hundreds of wallpapers. Still easy to manage.",
+			libraryText:
+				"Search, sort, filter, favourite, import, and tune playback in one native workspace. Local items, Workshop downloads, and presets stay together with their source clearly identified.",
+			libraryPoints: [
+				"Per-display assignment",
+				"Live playback controls",
+				"Custom properties",
+				"Menu-bar control",
+			],
+			libraryAlt: "The real Mirage installed wallpaper library",
+			workshopEyebrow: "Steam Workshop",
+			workshopTitle: "Browse, filter, and download without leaving Mirage.",
+			workshopText:
+				"Discover Workshop content by format, tag, popularity, rating, and recency. Mirage handles Steam sign-in, Steam Guard, concurrent downloads, live speed, and preset dependencies.",
+			workshopLink: "Open the Workshop guide",
+			workshopAlt: "Steam Workshop nature wallpapers inside Mirage",
+			rulesEyebrow: "Smart playback",
+			rulesTitle: "Motion that knows when to step back.",
+			rulesText:
+				"Choose what happens when another app is full screen, audio is playing, the display sleeps, or a MacBook switches to battery power.",
+			rulesLink: "Performance settings",
+			saverEyebrow: "Live screen saver",
+			saverTitle: "Your wallpaper keeps moving when you step away.",
+			saverText:
+				"Use the same scene, web, or video wallpaper as a standalone screen saver, with its preset and custom properties preserved.",
+			saverLink: "Screen saver guide",
+			displayEyebrow: "Per-display control",
+			displayTitle: "The right wallpaper on the right screen.",
+			displayText:
+				"See every connected display, apply the selected wallpaper to one screen, or stop individual renderers from a focused control panel.",
+			displayAlt: "Mirage display assignment panel",
+			displayLink: "Multi-display guide",
+			openEyebrow: "Open, transparent, supportable",
+			openTitle: "Built in the open — and free to use.",
+			openText:
+				"Mirage is GPL-3.0 software for macOS 14.2 and later. Sponsorship is optional and never unlocks or restricts features.",
+			openAlt: "Mirage About page with project and sponsorship information",
+			supportLink: "Support Mirage",
+			sourceLink: "Browse source",
+			finalTitle: "Give your desktop another dimension.",
+			finalText: "Available for Apple Silicon and Intel Macs.",
+			finalPrimary: "Download Mirage",
+			finalSecondary: "Start with the docs",
+			disclaimer:
+				"Mirage is not affiliated with or endorsed by Valve, Steam, or Wallpaper Engine.",
+		}
+	: {
+			badge: "macOS 原生动态壁纸",
+			heroLine1: "让喜欢的动态壁纸，",
+			heroLine2: "在 Mac 上醒来。",
+			heroText:
+				"场景、网页与视频壁纸，Steam 创意工坊、按显示器控制、智能播放策略和独立动态屏保，都在同一个原生 macOS 应用中。",
+			getStarted: "获取 Mirage",
+			readDocs: "阅读文档",
+			heroAlt: "Mirage 在 macOS 上实际渲染的动态场景壁纸",
+			heroCaption: "由 Mirage 实际渲染的场景壁纸",
+			heroMeta: "实时输出 · Scene 渲染器",
+			formatsEyebrow: "三种格式，一个壁纸库",
+			formatsTitle: "你已经喜欢的壁纸，继续在 Mac 上使用。",
+			formats: [
+				{
+					name: "SCENE",
+					title: "真正渲染的动态世界",
+					text: "通过 Vulkan 与 MoltenVK 呈现材质、粒子、灯光、特效和作品自定义属性。",
+					image: "/images/product/format-scene.webp",
+					alt: "Mirage 实际渲染的场景壁纸",
+				},
+				{
+					name: "WEB",
+					title: "可以交互的网页画布",
+					text: "WKWebView 承载 HTML、JavaScript、媒体、鼠标交互与音频响应。",
+					image: "/images/product/format-web.webp",
+					alt: "Mirage 中真实的网页音频可视化壁纸",
+				},
+				{
+					name: "VIDEO",
+					title: "无需折腾的流动画面",
+					text: "AVFoundation 负责本地视频壁纸的平滑循环、速度、音量和填充模式。",
+					image: "/images/product/format-video.webp",
+					alt: "Mirage 中真实的 4K 120 FPS 视频壁纸",
+				},
+			],
+			libraryEyebrow: "真实的 Mirage 壁纸库",
+			libraryTitle: "几百张壁纸，也依然清楚好用。",
+			libraryText:
+				"搜索、排序、筛选、收藏、导入和播放调节都在同一个原生工作区。本地作品、创意工坊下载和预设集中管理，同时保留清晰来源。",
+			libraryPoints: [
+				"按显示器独立指派",
+				"实时播放控制",
+				"作品自定义属性",
+				"菜单栏快捷控制",
+			],
+			libraryAlt: "真实的 Mirage 已安装壁纸库",
+			workshopEyebrow: "Steam 创意工坊",
+			workshopTitle: "浏览、筛选、下载，全程不必离开 Mirage。",
+			workshopText:
+				"按格式、标签、热度、评分与时间发现创意工坊内容。Steam 登录、Steam Guard、并发下载、实时速度和预设依赖均由 Mirage 管理。",
+			workshopLink: "打开创意工坊指南",
+			workshopAlt: "Mirage 中经过自然标签筛选的 Steam 创意工坊",
+			rulesEyebrow: "智能播放策略",
+			rulesTitle: "动态，也知道什么时候应该退场。",
+			rulesText:
+				"为其他应用全屏、播放音频、显示器睡眠和 MacBook 使用电池分别决定继续、静音、暂停或停止。",
+			rulesLink: "查看性能设置",
+			saverEyebrow: "动态屏保",
+			saverTitle: "离开电脑后，壁纸继续流动。",
+			saverText:
+				"同一张场景、网页或视频壁纸可以直接成为独立屏保，并保留当前预设与自定义属性。",
+			saverLink: "查看屏保指南",
+			displayEyebrow: "按显示器控制",
+			displayTitle: "每一块屏幕，都可以有自己的选择。",
+			displayText:
+				"集中查看连接的显示器，把当前壁纸应用到指定屏幕，或单独停止某个渲染器。",
+			displayAlt: "Mirage 显示器壁纸指派面板",
+			displayLink: "查看多显示器指南",
+			openEyebrow: "开放、透明、可持续",
+			openTitle: "开源构建，也始终免费使用。",
+			openText:
+				"Mirage 遵循 GPL-3.0，支持 macOS 14.2 及更高版本。赞助完全自愿，不会解锁或限制任何功能。",
+			openAlt: "Mirage 关于页面中的项目信息和赞助方式",
+			supportLink: "支持 Mirage",
+			sourceLink: "浏览源码",
+			finalTitle: "给桌面，再多一个维度。",
+			finalText: "同时支持 Apple Silicon 与 Intel Mac。",
+			finalPrimary: "下载 Mirage",
+			finalSecondary: "从文档开始",
+			disclaimer:
+				"Mirage 与 Valve、Steam 或 Wallpaper Engine 没有关联，也未获其官方认可。",
+		};
 ---
 
-<div class="mirage-landing">
+<div class="mirage-landing not-content">
   <main>
     <section class="hero-section landing-shell">
       <div class="hero-copy mirage-reveal">

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -1,7 +1,7 @@
-import { defineCollection } from 'astro:content';
-import { docsLoader } from '@astrojs/starlight/loaders';
-import { docsSchema } from '@astrojs/starlight/schema';
+import { defineCollection } from "astro:content";
+import { docsLoader } from "@astrojs/starlight/loaders";
+import { docsSchema } from "@astrojs/starlight/schema";
 
 export const collections = {
-  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+	docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
 };

--- a/website/src/pages/en/index.astro
+++ b/website/src/pages/en/index.astro
@@ -1,6 +1,6 @@
 ---
-import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
-import Landing from '../../components/Landing.astro';
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+import Landing from "../../components/Landing.astro";
 ---
 
 <StarlightPage

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
-import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
-import Landing from '../components/Landing.astro';
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+import Landing from "../components/Landing.astro";
 ---
 
 <StarlightPage

--- a/website/src/scripts/reveal.ts
+++ b/website/src/scripts/reveal.ts
@@ -2,38 +2,38 @@
 // enter the viewport. Motion itself is gated by `prefers-reduced-motion` in
 // CSS, so this only toggles a class — safe for reduced-motion users.
 function initReveal(): void {
-  const items = document.querySelectorAll<HTMLElement>('.mirage-reveal');
-  if (items.length === 0) return;
+	const items = document.querySelectorAll<HTMLElement>(".mirage-reveal");
+	if (items.length === 0) return;
 
-  // Fallback: if IntersectionObserver is missing, just show everything.
-  if (!('IntersectionObserver' in window)) {
-    items.forEach((el) => el.classList.add('is-visible'));
-    return;
-  }
+	// Fallback: if IntersectionObserver is missing, just show everything.
+	if (!("IntersectionObserver" in window)) {
+		items.forEach((el) => el.classList.add("is-visible"));
+		return;
+	}
 
-  const observer = new IntersectionObserver(
-    (entries) => {
-      for (const entry of entries) {
-        if (entry.isIntersecting) {
-          const el = entry.target as HTMLElement;
-          const delay = el.dataset.delay;
-          if (delay) el.style.animationDelay = `${delay}ms`;
-          el.classList.add('is-visible');
-          observer.unobserve(el);
-        }
-      }
-    },
-    { rootMargin: '0px 0px -10% 0px', threshold: 0.1 },
-  );
+	const observer = new IntersectionObserver(
+		(entries) => {
+			for (const entry of entries) {
+				if (entry.isIntersecting) {
+					const el = entry.target as HTMLElement;
+					const delay = el.dataset.delay;
+					if (delay) el.style.animationDelay = `${delay}ms`;
+					el.classList.add("is-visible");
+					observer.unobserve(el);
+				}
+			}
+		},
+		{ rootMargin: "0px 0px -10% 0px", threshold: 0.1 },
+	);
 
-  items.forEach((el) => observer.observe(el));
+	items.forEach((el) => observer.observe(el));
 }
 
-if (document.readyState !== 'loading') {
-  initReveal();
+if (document.readyState !== "loading") {
+	initReveal();
 } else {
-  document.addEventListener('DOMContentLoaded', initReveal);
+	document.addEventListener("DOMContentLoaded", initReveal);
 }
 
 // Re-run after Astro client-side navigation (view transitions).
-document.addEventListener('astro:page-load', initReveal);
+document.addEventListener("astro:page-load", initReveal);

--- a/website/src/styles/landing.css
+++ b/website/src/styles/landing.css
@@ -1,112 +1,653 @@
-body:has(.mirage-landing) .sl-markdown-content{margin:0!important}
-body:has(.mirage-landing) .content-panel{padding:0!important}
-body:has(.mirage-landing) .main-pane{width:100%}
-.sl-container:has(.mirage-landing)>.hero{display:none}
-.sl-container:has(.mirage-landing),.sl-container:has(.mirage-landing)>main{max-width:none;padding:0}
-
-.mirage-landing{
-  --landing-bg:var(--sl-color-black);
-  --landing-panel:var(--sl-color-gray-6);
-  --landing-panel-strong:color-mix(in srgb,var(--sl-color-gray-6) 76%,var(--sl-color-gray-5));
-  --landing-ink:var(--sl-color-white);
-  --landing-muted:var(--sl-color-gray-2);
-  --landing-soft:var(--sl-color-gray-3);
-  --landing-line:var(--sl-color-gray-5);
-  --landing-accent:var(--sl-color-accent);
-  color:var(--landing-ink);
-  background:var(--landing-bg);
-  overflow:clip;
-  font-family:-apple-system,BlinkMacSystemFont,"SF Pro Display","SF Pro Text","PingFang SC",system-ui,sans-serif;
+body:has(.mirage-landing) .sl-markdown-content {
+	margin: 0 !important;
 }
-.mirage-landing *{box-sizing:border-box}
-.mirage-landing img{display:block;max-width:100%;height:auto}
-.landing-shell{width:min(1180px,calc(100% - 48px));margin-inline:auto}
-
-.hero-section{position:relative;padding:92px 0 118px}
-.hero-section:before{content:"";position:absolute;width:72%;height:520px;top:-180px;left:14%;z-index:0;background:radial-gradient(ellipse,color-mix(in srgb,var(--landing-accent) 15%,transparent),transparent 68%);pointer-events:none}
-.hero-copy{position:relative;z-index:1;text-align:center;display:flex;flex-direction:column;align-items:center}
-.product-badge{display:inline-flex;align-items:center;gap:.55rem;padding:.36rem .7rem .36rem .4rem;border:1px solid var(--landing-line);border-radius:999px;background:color-mix(in srgb,var(--landing-panel) 78%,transparent);color:var(--landing-muted);font-size:.74rem}
-.product-badge img{width:24px;height:24px;border-radius:6px}
-.hero-copy h1{max-width:1040px;margin:1.55rem auto 0;font-size:clamp(4rem,7vw,7rem);line-height:.92;letter-spacing:-.075em;font-weight:650;text-wrap:balance}
-.hero-copy h1 span{display:block;color:var(--landing-accent)}
-.hero-copy>p{max-width:760px;margin:1.55rem auto 0;color:var(--landing-muted);font-size:clamp(1rem,1.45vw,1.18rem);line-height:1.75;text-wrap:balance}
-.hero-actions{display:flex;justify-content:center;gap:.7rem;margin-top:1.8rem;flex-wrap:wrap}
-.primary-action,.secondary-action{min-height:48px;padding:.75rem 1.2rem;display:inline-flex;align-items:center;justify-content:center;gap:.55rem;border-radius:11px;text-decoration:none;font-size:.91rem;font-weight:680;transition:transform .22s var(--mirage-ease),background .22s,border-color .22s}
-.primary-action{color:var(--landing-bg);background:var(--landing-ink);box-shadow:0 14px 34px color-mix(in srgb,var(--landing-bg) 45%,transparent)}
-.secondary-action{color:var(--landing-ink);border:1px solid var(--landing-line);background:var(--landing-panel)}
-.primary-action:hover,.secondary-action:hover{transform:translateY(-2px)}
-.secondary-action:hover{border-color:var(--landing-soft)}
-
-.hero-visual{position:relative;z-index:1;margin:56px 0 0!important;border:1px solid var(--landing-line);border-radius:24px;overflow:hidden;background:var(--landing-panel);box-shadow:0 55px 120px -65px color-mix(in srgb,var(--landing-accent) 55%,transparent)}
-.hero-visual>img{width:100%;aspect-ratio:16/9;object-fit:cover}
-.hero-visual figcaption{min-height:58px;padding:0 20px;display:flex;align-items:center;justify-content:space-between;gap:1rem;border-top:1px solid var(--landing-line);color:var(--landing-muted);font-size:.75rem}
-.hero-visual figcaption strong{color:var(--landing-ink);font-weight:600}
-.hero-stage-enter{animation:mirage-fade-up .8s .12s var(--mirage-ease) both}
-
-.section-heading{max-width:840px}
-.section-heading>p,.section-kicker{margin:0 0 1rem;color:var(--landing-accent);font-size:.7rem;font-weight:730;letter-spacing:.14em;text-transform:uppercase}
-.section-heading h2,.feature-copy h2,.workshop-copy h2,.paired-card h2,.display-copy h2,.closing-section h2{margin:0;color:var(--landing-ink);font-size:clamp(2.65rem,5vw,5rem);line-height:1.02;letter-spacing:-.06em;font-weight:620;text-wrap:balance}
-
-.format-section{padding:145px 0}
-.format-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:18px;margin-top:62px}
-.format-item{min-width:0;border:1px solid var(--landing-line);border-radius:20px;overflow:hidden;background:var(--landing-panel)}
-.format-item>img{width:100%;aspect-ratio:1/1;object-fit:cover;border-bottom:1px solid var(--landing-line)}
-.format-item>div{padding:28px}
-.format-item span{color:var(--landing-accent);font-size:.68rem;font-weight:760;letter-spacing:.14em}
-.format-item h3{margin:1rem 0 .7rem;color:var(--landing-ink);font-size:1.42rem;letter-spacing:-.04em}
-.format-item p{margin:0;color:var(--landing-muted);font-size:.89rem;line-height:1.7}
-
-.feature-section{padding:135px 0;border-block:1px solid var(--landing-line);background:var(--landing-panel)}
-.feature-light{background:color-mix(in srgb,var(--landing-panel) 64%,var(--landing-bg))}
-.feature-grid{display:grid;grid-template-columns:.8fr 1.2fr;align-items:center;gap:7vw}
-.feature-copy>p:not(.section-kicker),.workshop-copy>p:not(.section-kicker),.paired-card div>p:not(.section-kicker),.display-copy>p:not(.section-kicker){margin:1.4rem 0 0;color:var(--landing-muted);line-height:1.78;max-width:52ch}
-.feature-copy ul{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.85rem 1.2rem;padding:0;margin:2rem 0 0;list-style:none}
-.feature-copy li{color:var(--landing-muted);font-size:.84rem;display:flex;align-items:center;gap:.6rem}
-.feature-copy li:before{content:"";width:6px;height:6px;flex:0 0 auto;border-radius:50%;background:var(--landing-accent)}
-.app-shot{margin:0!important;border:1px solid var(--landing-line);border-radius:18px;overflow:hidden;background:var(--landing-bg);box-shadow:0 34px 75px color-mix(in srgb,var(--landing-bg) 36%,transparent)}
-.app-shot img{width:100%}
-
-.workshop-section{padding:150px 0;display:grid;grid-template-columns:.7fr 1.3fr;align-items:center;gap:6vw}
-.text-link{display:inline-flex;align-items:center;gap:.55rem;margin-top:1.25rem;color:var(--landing-accent);text-decoration:none;font-size:.86rem;font-weight:680}
-.text-link:hover{text-decoration:underline;text-underline-offset:.3em}
-.workshop-shot{aspect-ratio:1.5/1}
-.workshop-shot img{width:100%;height:100%;object-fit:cover;object-position:right center}
-
-.paired-section{padding:128px 0;background:var(--landing-panel);border-block:1px solid var(--landing-line)}
-.paired-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:22px}
-.paired-card{min-width:0;display:flex;flex-direction:column;border:1px solid var(--landing-line);border-radius:22px;overflow:hidden;background:var(--landing-bg)}
-.paired-card>div{padding:42px 42px 38px;flex:1}
-.paired-card h2{font-size:clamp(2.15rem,3.3vw,3.5rem)}
-.paired-card>img{width:100%;border-top:1px solid var(--landing-line)}
-
-.display-section{padding:145px 0;display:grid;grid-template-columns:1fr .8fr;gap:8vw;align-items:center}
-.display-shot{margin:0!important;border:1px solid var(--landing-line);border-radius:22px;overflow:hidden;background:var(--landing-panel);box-shadow:0 34px 75px color-mix(in srgb,var(--landing-bg) 34%,transparent)}
-.display-shot img{width:100%}
-
-.open-section{background:color-mix(in srgb,var(--landing-panel) 75%,var(--landing-bg))}
-.inline-links{display:flex;gap:1.5rem;flex-wrap:wrap}
-.closing-section{text-align:center;padding:128px 24px;margin-block:110px!important;border:1px solid var(--landing-line);border-radius:28px;background:var(--landing-panel)}
-.closing-section>img{margin-inline:auto;border-radius:17px;box-shadow:0 16px 44px color-mix(in srgb,var(--landing-bg) 50%,transparent)}
-.closing-section h2{max-width:850px;margin:1.6rem auto 0}
-.closing-section>p{margin:1.1rem auto 0;color:var(--landing-muted)}
-.landing-footer{min-height:118px;display:flex;align-items:center;justify-content:space-between;gap:2rem;border-top:1px solid var(--landing-line);color:var(--landing-soft);font-size:.72rem}
-.landing-footer>a{display:inline-flex;align-items:center;gap:.6rem;color:var(--landing-ink);text-decoration:none}
-.landing-footer>a img{border-radius:8px}.landing-footer p{text-align:center;max-width:540px}
-
-@media(prefers-reduced-motion:reduce){.hero-stage-enter{animation:none}}
-@media(max-width:900px){
-  .hero-section{padding:72px 0 90px}.hero-copy h1{font-size:clamp(3.5rem,10vw,5.5rem)}
-  .format-grid{grid-template-columns:1fr}.format-item{display:grid;grid-template-columns:minmax(220px,.8fr) 1.2fr}.format-item>img{height:100%;aspect-ratio:auto;border-bottom:0;border-right:1px solid var(--landing-line)}.format-item>div{align-self:center}
-  .feature-grid,.workshop-section,.display-section{grid-template-columns:1fr;gap:52px}.feature-copy,.workshop-copy,.display-copy{max-width:680px}.workshop-shot{order:-1}.display-copy{order:-1}
-  .paired-grid{grid-template-columns:1fr}.paired-card{display:grid;grid-template-columns:1fr 1fr}.paired-card>img{height:100%;object-fit:cover;border-top:0;border-left:1px solid var(--landing-line)}
+body:has(.mirage-landing) .content-panel {
+	padding: 0 !important;
 }
-@media(max-width:600px){
-  .landing-shell{width:min(100% - 32px,1180px)}
-  .hero-section{padding:52px 0 72px}.hero-copy{align-items:flex-start;text-align:left}.hero-copy h1{font-size:clamp(2.7rem,13.4vw,4.1rem);line-height:.96;letter-spacing:-.065em;text-wrap:pretty}.hero-copy>p{font-size:.98rem;line-height:1.68;text-wrap:pretty}.hero-actions{width:100%;justify-content:flex-start}.primary-action,.secondary-action{flex:1;min-width:135px}
-  .hero-visual{margin-top:38px!important;border-radius:16px}.hero-visual figcaption{min-height:64px;padding:10px 13px;align-items:flex-start;justify-content:center;flex-direction:column;gap:.18rem}.hero-visual figcaption span{font-size:.68rem}
-  .format-section,.feature-section,.workshop-section,.paired-section,.display-section{padding:78px 0}.section-heading h2,.feature-copy h2,.workshop-copy h2,.display-copy h2,.closing-section h2{font-size:clamp(2.3rem,11vw,3.35rem)}.format-grid{margin-top:38px;gap:14px}.format-item{display:block}.format-item>img{width:100%;height:auto;aspect-ratio:16/10;border-right:0;border-bottom:1px solid var(--landing-line)}.format-item>div{padding:24px}.format-item h3{font-size:1.3rem}
-  .feature-grid,.workshop-section,.display-section{gap:34px}.feature-copy ul{grid-template-columns:1fr}.app-shot,.display-shot{border-radius:14px}.workshop-shot{aspect-ratio:1.2/1}.workshop-shot img{object-position:72% center}
-  .paired-grid{gap:14px}.paired-card{display:block;border-radius:16px}.paired-card>div{padding:28px 24px}.paired-card h2{font-size:2.2rem}.paired-card>img{height:auto;border-left:0;border-top:1px solid var(--landing-line)}
-  .closing-section{padding:76px 20px;margin-block:72px!important;border-radius:20px}.closing-section .hero-actions{justify-content:center}
-  .landing-footer{padding:28px 0;min-height:auto;flex-wrap:wrap}.landing-footer p{order:3;text-align:left;margin:0}.landing-footer>span{margin-left:auto}
+body:has(.mirage-landing) .main-pane {
+	width: 100%;
+}
+.sl-container:has(.mirage-landing) > .hero {
+	display: none;
+}
+.sl-container:has(.mirage-landing),
+.sl-container:has(.mirage-landing) > main {
+	max-width: none;
+	padding: 0;
+}
+
+.mirage-landing {
+	--landing-bg: var(--sl-color-black);
+	--landing-panel: var(--sl-color-gray-6);
+	--landing-panel-strong: color-mix(
+		in srgb,
+		var(--sl-color-gray-6) 76%,
+		var(--sl-color-gray-5)
+	);
+	--landing-ink: var(--sl-color-white);
+	--landing-muted: var(--sl-color-gray-2);
+	--landing-soft: var(--sl-color-gray-3);
+	--landing-line: var(--sl-color-gray-5);
+	--landing-accent: var(--sl-color-accent);
+	color: var(--landing-ink);
+	background: var(--landing-bg);
+	overflow: clip;
+	font-family:
+		-apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text",
+		"PingFang SC", system-ui, sans-serif;
+}
+.mirage-landing * {
+	box-sizing: border-box;
+}
+.mirage-landing img {
+	display: block;
+	max-width: 100%;
+	height: auto;
+}
+.landing-shell {
+	width: min(1180px, calc(100% - 48px));
+	margin-inline: auto;
+}
+
+.hero-section {
+	position: relative;
+	padding: 92px 0 118px;
+}
+.hero-section:before {
+	content: "";
+	position: absolute;
+	width: 72%;
+	height: 520px;
+	top: -180px;
+	left: 14%;
+	z-index: 0;
+	background: radial-gradient(
+		ellipse,
+		color-mix(in srgb, var(--landing-accent) 15%, transparent),
+		transparent 68%
+	);
+	pointer-events: none;
+}
+.hero-copy {
+	position: relative;
+	z-index: 1;
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+}
+.product-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.55rem;
+	padding: 0.36rem 0.7rem 0.36rem 0.4rem;
+	border: 1px solid var(--landing-line);
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--landing-panel) 78%, transparent);
+	color: var(--landing-muted);
+	font-size: 0.74rem;
+}
+.product-badge img {
+	width: 24px;
+	height: 24px;
+	border-radius: 6px;
+}
+.hero-copy h1 {
+	max-width: 1040px;
+	margin: 1.55rem auto 0;
+	font-size: clamp(4rem, 7vw, 7rem);
+	line-height: 0.92;
+	letter-spacing: -0.075em;
+	font-weight: 650;
+	text-wrap: balance;
+}
+.hero-copy h1 span {
+	display: block;
+	color: var(--landing-accent);
+}
+.hero-copy > p {
+	max-width: 760px;
+	margin: 1.55rem auto 0;
+	color: var(--landing-muted);
+	font-size: clamp(1rem, 1.45vw, 1.18rem);
+	line-height: 1.75;
+	text-wrap: balance;
+}
+.hero-actions {
+	display: flex;
+	justify-content: center;
+	gap: 0.7rem;
+	margin-top: 1.8rem;
+	flex-wrap: wrap;
+}
+.primary-action,
+.secondary-action {
+	min-height: 48px;
+	padding: 0.75rem 1.2rem;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 0.55rem;
+	border-radius: 11px;
+	text-decoration: none;
+	font-size: 0.91rem;
+	font-weight: 680;
+	transition:
+		transform 0.22s var(--mirage-ease),
+		background 0.22s,
+		border-color 0.22s;
+}
+.primary-action {
+	color: var(--landing-bg);
+	background: var(--landing-ink);
+	box-shadow: 0 14px 34px color-mix(in srgb, var(--landing-bg) 45%, transparent);
+}
+.secondary-action {
+	color: var(--landing-ink);
+	border: 1px solid var(--landing-line);
+	background: var(--landing-panel);
+}
+.primary-action:hover,
+.secondary-action:hover {
+	transform: translateY(-2px);
+}
+.secondary-action:hover {
+	border-color: var(--landing-soft);
+}
+
+.hero-visual {
+	position: relative;
+	z-index: 1;
+	margin: 56px 0 0 !important;
+	border: 1px solid var(--landing-line);
+	border-radius: 24px;
+	overflow: hidden;
+	background: var(--landing-panel);
+	box-shadow: 0 55px 120px -65px
+		color-mix(in srgb, var(--landing-accent) 55%, transparent);
+}
+.hero-visual > img {
+	width: 100%;
+	aspect-ratio: 16 / 9;
+	object-fit: cover;
+}
+.hero-visual figcaption {
+	min-height: 58px;
+	padding: 0 20px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+	border-top: 1px solid var(--landing-line);
+	color: var(--landing-muted);
+	font-size: 0.75rem;
+}
+.hero-visual figcaption strong {
+	color: var(--landing-ink);
+	font-weight: 600;
+}
+.hero-stage-enter {
+	animation: mirage-fade-up 0.8s 0.12s var(--mirage-ease) both;
+}
+
+.section-heading {
+	max-width: 840px;
+}
+.section-heading > p,
+.section-kicker {
+	margin: 0 0 1rem;
+	color: var(--landing-accent);
+	font-size: 0.7rem;
+	font-weight: 730;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+}
+.section-heading h2,
+.feature-copy h2,
+.workshop-copy h2,
+.paired-card h2,
+.display-copy h2,
+.closing-section h2 {
+	margin: 0;
+	color: var(--landing-ink);
+	font-size: clamp(2.65rem, 5vw, 5rem);
+	line-height: 1.02;
+	letter-spacing: -0.06em;
+	font-weight: 620;
+	text-wrap: balance;
+}
+
+.format-section {
+	padding: 145px 0;
+}
+.format-grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 18px;
+	margin-top: 62px;
+}
+.format-item {
+	min-width: 0;
+	border: 1px solid var(--landing-line);
+	border-radius: 20px;
+	overflow: hidden;
+	background: var(--landing-panel);
+}
+.format-item > img {
+	width: 100%;
+	aspect-ratio: 1 / 1;
+	object-fit: cover;
+	border-bottom: 1px solid var(--landing-line);
+}
+.format-item > div {
+	padding: 28px;
+}
+.format-item span {
+	color: var(--landing-accent);
+	font-size: 0.68rem;
+	font-weight: 760;
+	letter-spacing: 0.14em;
+}
+.format-item h3 {
+	margin: 1rem 0 0.7rem;
+	color: var(--landing-ink);
+	font-size: 1.42rem;
+	letter-spacing: -0.04em;
+}
+.format-item p {
+	margin: 0;
+	color: var(--landing-muted);
+	font-size: 0.89rem;
+	line-height: 1.7;
+}
+
+.feature-section {
+	padding: 135px 0;
+	border-block: 1px solid var(--landing-line);
+	background: var(--landing-panel);
+}
+.feature-light {
+	background: color-mix(in srgb, var(--landing-panel) 64%, var(--landing-bg));
+}
+.feature-grid {
+	display: grid;
+	grid-template-columns: 0.8fr 1.2fr;
+	align-items: center;
+	gap: 7vw;
+}
+.feature-copy > p:not(.section-kicker),
+.workshop-copy > p:not(.section-kicker),
+.paired-card div > p:not(.section-kicker),
+.display-copy > p:not(.section-kicker) {
+	margin: 1.4rem 0 0;
+	color: var(--landing-muted);
+	line-height: 1.78;
+	max-width: 52ch;
+}
+.feature-copy ul {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 0.85rem 1.2rem;
+	padding: 0;
+	margin: 2rem 0 0;
+	list-style: none;
+}
+.feature-copy li {
+	color: var(--landing-muted);
+	font-size: 0.84rem;
+	display: flex;
+	align-items: center;
+	gap: 0.6rem;
+}
+.feature-copy li:before {
+	content: "";
+	width: 6px;
+	height: 6px;
+	flex: 0 0 auto;
+	border-radius: 50%;
+	background: var(--landing-accent);
+}
+.app-shot {
+	margin: 0 !important;
+	border: 1px solid var(--landing-line);
+	border-radius: 18px;
+	overflow: hidden;
+	background: var(--landing-bg);
+	box-shadow: 0 34px 75px color-mix(in srgb, var(--landing-bg) 36%, transparent);
+}
+.app-shot img {
+	width: 100%;
+}
+
+.workshop-section {
+	padding: 150px 0;
+	display: grid;
+	grid-template-columns: 0.7fr 1.3fr;
+	align-items: center;
+	gap: 6vw;
+}
+.text-link {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.55rem;
+	margin-top: 1.25rem;
+	color: var(--landing-accent);
+	text-decoration: none;
+	font-size: 0.86rem;
+	font-weight: 680;
+}
+.text-link:hover {
+	text-decoration: underline;
+	text-underline-offset: 0.3em;
+}
+.workshop-shot {
+	aspect-ratio: 1.5 / 1;
+}
+.workshop-shot img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	object-position: right center;
+}
+
+.paired-section {
+	padding: 128px 0;
+	background: var(--landing-panel);
+	border-block: 1px solid var(--landing-line);
+}
+.paired-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 22px;
+}
+.paired-card {
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	border: 1px solid var(--landing-line);
+	border-radius: 22px;
+	overflow: hidden;
+	background: var(--landing-bg);
+}
+.paired-card > div {
+	padding: 42px 42px 38px;
+	flex: 1;
+}
+.paired-card h2 {
+	font-size: clamp(2.15rem, 3.3vw, 3.5rem);
+}
+.paired-card > img {
+	width: 100%;
+	border-top: 1px solid var(--landing-line);
+}
+
+.display-section {
+	padding: 145px 0;
+	display: grid;
+	grid-template-columns: 1fr 0.8fr;
+	gap: 8vw;
+	align-items: center;
+}
+.display-shot {
+	margin: 0 !important;
+	border: 1px solid var(--landing-line);
+	border-radius: 22px;
+	overflow: hidden;
+	background: var(--landing-panel);
+	box-shadow: 0 34px 75px color-mix(in srgb, var(--landing-bg) 34%, transparent);
+}
+.display-shot img {
+	width: 100%;
+}
+
+.open-section {
+	background: color-mix(in srgb, var(--landing-panel) 75%, var(--landing-bg));
+}
+.inline-links {
+	display: flex;
+	gap: 1.5rem;
+	flex-wrap: wrap;
+}
+.closing-section {
+	text-align: center;
+	padding: 128px 24px;
+	margin-block: 110px !important;
+	border: 1px solid var(--landing-line);
+	border-radius: 28px;
+	background: var(--landing-panel);
+}
+.closing-section > img {
+	margin-inline: auto;
+	border-radius: 17px;
+	box-shadow: 0 16px 44px color-mix(in srgb, var(--landing-bg) 50%, transparent);
+}
+.closing-section h2 {
+	max-width: 850px;
+	margin: 1.6rem auto 0;
+}
+.closing-section > p {
+	margin: 1.1rem auto 0;
+	color: var(--landing-muted);
+}
+.landing-footer {
+	min-height: 118px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 2rem;
+	border-top: 1px solid var(--landing-line);
+	color: var(--landing-soft);
+	font-size: 0.72rem;
+}
+.landing-footer > a {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.6rem;
+	color: var(--landing-ink);
+	text-decoration: none;
+}
+.landing-footer > a img {
+	border-radius: 8px;
+}
+.landing-footer p {
+	text-align: center;
+	max-width: 540px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.hero-stage-enter {
+		animation: none;
+	}
+}
+@media (max-width: 900px) {
+	.hero-section {
+		padding: 72px 0 90px;
+	}
+	.hero-copy h1 {
+		font-size: clamp(3.5rem, 10vw, 5.5rem);
+	}
+	.format-grid {
+		grid-template-columns: 1fr;
+	}
+	.format-item {
+		display: grid;
+		grid-template-columns: minmax(220px, 0.8fr) 1.2fr;
+	}
+	.format-item > img {
+		height: 100%;
+		aspect-ratio: auto;
+		border-bottom: 0;
+		border-right: 1px solid var(--landing-line);
+	}
+	.format-item > div {
+		align-self: center;
+	}
+	.feature-grid,
+	.workshop-section,
+	.display-section {
+		grid-template-columns: 1fr;
+		gap: 52px;
+	}
+	.feature-copy,
+	.workshop-copy,
+	.display-copy {
+		max-width: 680px;
+	}
+	.workshop-shot {
+		order: -1;
+	}
+	.display-copy {
+		order: -1;
+	}
+	.paired-grid {
+		grid-template-columns: 1fr;
+	}
+	.paired-card {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+	}
+	.paired-card > img {
+		height: 100%;
+		object-fit: cover;
+		border-top: 0;
+		border-left: 1px solid var(--landing-line);
+	}
+}
+@media (max-width: 600px) {
+	.landing-shell {
+		width: min(100% - 32px, 1180px);
+	}
+	.hero-section {
+		padding: 52px 0 72px;
+	}
+	.hero-copy {
+		align-items: flex-start;
+		text-align: left;
+	}
+	.hero-copy h1 {
+		font-size: clamp(2.7rem, 13.4vw, 4.1rem);
+		line-height: 0.96;
+		letter-spacing: -0.065em;
+		text-wrap: pretty;
+	}
+	.hero-copy > p {
+		font-size: 0.98rem;
+		line-height: 1.68;
+		text-wrap: pretty;
+	}
+	.hero-actions {
+		width: 100%;
+		justify-content: flex-start;
+	}
+	.primary-action,
+	.secondary-action {
+		flex: 1;
+		min-width: 135px;
+	}
+	.hero-visual {
+		margin-top: 38px !important;
+		border-radius: 16px;
+	}
+	.hero-visual figcaption {
+		min-height: 64px;
+		padding: 10px 13px;
+		align-items: flex-start;
+		justify-content: center;
+		flex-direction: column;
+		gap: 0.18rem;
+	}
+	.hero-visual figcaption span {
+		font-size: 0.68rem;
+	}
+	.format-section,
+	.feature-section,
+	.workshop-section,
+	.paired-section,
+	.display-section {
+		padding: 78px 0;
+	}
+	.section-heading h2,
+	.feature-copy h2,
+	.workshop-copy h2,
+	.display-copy h2,
+	.closing-section h2 {
+		font-size: clamp(2.3rem, 11vw, 3.35rem);
+	}
+	.format-grid {
+		margin-top: 38px;
+		gap: 14px;
+	}
+	.format-item {
+		display: block;
+	}
+	.format-item > img {
+		width: 100%;
+		height: auto;
+		aspect-ratio: 16 / 10;
+		border-right: 0;
+		border-bottom: 1px solid var(--landing-line);
+	}
+	.format-item > div {
+		padding: 24px;
+	}
+	.format-item h3 {
+		font-size: 1.3rem;
+	}
+	.feature-grid,
+	.workshop-section,
+	.display-section {
+		gap: 34px;
+	}
+	.feature-copy ul {
+		grid-template-columns: 1fr;
+	}
+	.app-shot,
+	.display-shot {
+		border-radius: 14px;
+	}
+	.workshop-shot {
+		aspect-ratio: 1.2 / 1;
+	}
+	.workshop-shot img {
+		object-position: 72% center;
+	}
+	.paired-grid {
+		gap: 14px;
+	}
+	.paired-card {
+		display: block;
+		border-radius: 16px;
+	}
+	.paired-card > div {
+		padding: 28px 24px;
+	}
+	.paired-card h2 {
+		font-size: 2.2rem;
+	}
+	.paired-card > img {
+		height: auto;
+		border-left: 0;
+		border-top: 1px solid var(--landing-line);
+	}
+	.closing-section {
+		padding: 76px 20px;
+		margin-block: 72px !important;
+		border-radius: 20px;
+	}
+	.closing-section .hero-actions {
+		justify-content: center;
+	}
+	.landing-footer {
+		padding: 28px 0;
+		min-height: auto;
+		flex-wrap: wrap;
+	}
+	.landing-footer p {
+		order: 3;
+		text-align: left;
+		margin: 0;
+	}
+	.landing-footer > span {
+		margin-left: auto;
+	}
 }

--- a/website/src/styles/theme.css
+++ b/website/src/styles/theme.css
@@ -1,14 +1,232 @@
-:root{--sl-color-accent-low:#102e3d;--sl-color-accent:#67cce9;--sl-color-accent-high:#bee9f7;--sl-color-white:#edf4fb;--sl-color-gray-1:#c5d2dc;--sl-color-gray-2:#9badb9;--sl-color-gray-3:#778b99;--sl-color-gray-4:#4a5c68;--sl-color-gray-5:#283a45;--sl-color-gray-6:#14232d;--sl-color-black:#071017;--sl-font:-apple-system,BlinkMacSystemFont,"SF Pro Display","SF Pro Text","PingFang SC","Hiragino Sans GB",system-ui,sans-serif;--sl-font-mono:"SF Mono",ui-monospace,Menlo,Consolas,monospace;--mirage-ease:cubic-bezier(.22,1,.36,1)}:root[data-theme=light]{--sl-color-accent-low:#d6f2fa;--sl-color-accent:#167c9d;--sl-color-accent-high:#08364a;--sl-color-white:#10212a;--sl-color-gray-1:#253944;--sl-color-gray-2:#4e6572;--sl-color-gray-3:#6f8490;--sl-color-gray-4:#a6b6be;--sl-color-gray-5:#ced9de;--sl-color-gray-6:#edf3f5;--sl-color-black:#fbfdfe}html{scroll-behavior:smooth}body{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}:focus-visible{outline:2px solid #73d5f2;outline-offset:3px;border-radius:4px}.site-title{font-weight:650;letter-spacing:-.035em}.site-title img{border-radius:6px}.header{border-bottom:1px solid var(--sl-color-gray-5);backdrop-filter:blur(18px)}.sidebar{border-right:1px solid var(--sl-color-gray-5)}.sidebar-content{background:color-mix(in srgb,var(--sl-color-black) 82%,transparent)}.main-frame{background:radial-gradient(700px 500px at 80% -10%,color-mix(in srgb,var(--sl-color-accent) 9%,transparent),transparent 65%)}.sl-markdown-content{font-size:1rem;line-height:1.78}.sl-markdown-content :is(h1,h2,h3){font-weight:650;letter-spacing:-.04em;scroll-margin-top:6rem}.sl-markdown-content h1{font-size:clamp(2.1rem,5vw,3.45rem)}.sl-markdown-content h2{margin-top:3.25rem;padding-bottom:.55rem;border-bottom:1px solid var(--sl-color-gray-5)}.sl-markdown-content h3{margin-top:2.1rem}.sl-markdown-content :is(code:not(pre code),kbd){border:1px solid var(--sl-color-gray-5);border-radius:5px}.sl-markdown-content pre{border:1px solid var(--sl-color-gray-5);box-shadow:0 12px 40px #0002}.sl-markdown-content table{display:table;overflow:hidden;border:1px solid var(--sl-color-gray-5);border-radius:9px}.sl-markdown-content a{text-underline-offset:.2em}.sl-link-card{border-radius:10px;transition:border-color .2s ease,transform .2s var(--mirage-ease)}.sl-link-card:hover{transform:translateY(-2px);border-color:var(--sl-color-accent)}.starlight-aside,.pagination-links a{border-radius:8px}.right-sidebar-panel{border-left:1px solid var(--sl-color-gray-5)}@keyframes mirage-fade-up{from{opacity:0;transform:translateY(18px)}to{opacity:1;transform:translateY(0)}}.mirage-reveal{opacity:0;transform:translateY(18px)}.mirage-reveal.is-visible{animation:mirage-fade-up .7s var(--mirage-ease) forwards}@media(prefers-reduced-motion:reduce){*,*:before,*:after{animation-duration:.001ms!important;animation-iteration-count:1!important;transition-duration:.001ms!important;scroll-behavior:auto!important}.mirage-reveal{opacity:1;transform:none}}
+:root {
+	--sl-color-accent-low: #102e3d;
+	--sl-color-accent: #67cce9;
+	--sl-color-accent-high: #bee9f7;
+	--sl-color-white: #edf4fb;
+	--sl-color-gray-1: #c5d2dc;
+	--sl-color-gray-2: #9badb9;
+	--sl-color-gray-3: #778b99;
+	--sl-color-gray-4: #4a5c68;
+	--sl-color-gray-5: #283a45;
+	--sl-color-gray-6: #14232d;
+	--sl-color-black: #071017;
+	--sl-font:
+		-apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text",
+		"PingFang SC", "Hiragino Sans GB", system-ui, sans-serif;
+	--sl-font-mono: "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+	--mirage-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+:root[data-theme="light"] {
+	--sl-color-accent-low: #d6f2fa;
+	--sl-color-accent: #167c9d;
+	--sl-color-accent-high: #08364a;
+	--sl-color-white: #10212a;
+	--sl-color-gray-1: #253944;
+	--sl-color-gray-2: #4e6572;
+	--sl-color-gray-3: #6f8490;
+	--sl-color-gray-4: #a6b6be;
+	--sl-color-gray-5: #ced9de;
+	--sl-color-gray-6: #edf3f5;
+	--sl-color-black: #fbfdfe;
+}
+html {
+	scroll-behavior: smooth;
+}
+body {
+	-webkit-font-smoothing: antialiased;
+	text-rendering: optimizeLegibility;
+}
+:focus-visible {
+	outline: 2px solid #73d5f2;
+	outline-offset: 3px;
+	border-radius: 4px;
+}
+.site-title {
+	font-weight: 650;
+	letter-spacing: -0.035em;
+}
+.site-title img {
+	border-radius: 6px;
+}
+header {
+    border-bottom: 1px solid var(--sl-color-gray-5);
+    backdrop-filter: blur(18px);
+}
+header > .header {
+    border-bottom: none;
+    backdrop-filter: none;
+}
+.sidebar {
+	border-right: 1px solid var(--sl-color-gray-5);
+}
+.sidebar-content {
+	background: color-mix(in srgb, var(--sl-color-black) 82%, transparent);
+}
+.main-frame {
+	background: radial-gradient(
+		700px 500px at 80% -10%,
+		color-mix(in srgb, var(--sl-color-accent) 9%, transparent),
+		transparent 65%
+	);
+}
+.sl-markdown-content {
+	font-size: 1rem;
+	line-height: 1.78;
+}
+.sl-markdown-content :is(h1, h2, h3) {
+	font-weight: 650;
+	letter-spacing: -0.04em;
+	scroll-margin-top: 6rem;
+}
+.sl-markdown-content h1 {
+	font-size: clamp(2.1rem, 5vw, 3.45rem);
+}
+.sl-markdown-content h2 {
+	margin-top: 3.25rem;
+	padding-bottom: 0.55rem;
+	border-bottom: 1px solid var(--sl-color-gray-5);
+}
+.sl-markdown-content h3 {
+	margin-top: 2.1rem;
+}
+.sl-markdown-content :is(code:not(pre code), kbd) {
+	border: 1px solid var(--sl-color-gray-5);
+	border-radius: 5px;
+}
+.sl-markdown-content pre {
+	border: 1px solid var(--sl-color-gray-5);
+	box-shadow: 0 12px 40px #0002;
+}
+.sl-markdown-content table {
+	display: table;
+	overflow: hidden;
+	border: 1px solid var(--sl-color-gray-5);
+	border-radius: 9px;
+}
+.sl-markdown-content a {
+	text-underline-offset: 0.2em;
+}
+.sl-link-card {
+	border-radius: 10px;
+	transition:
+		border-color 0.2s ease,
+		transform 0.2s var(--mirage-ease);
+}
+.sl-link-card:hover {
+	transform: translateY(-2px);
+	border-color: var(--sl-color-accent);
+}
+.starlight-aside,
+.pagination-links a {
+	border-radius: 8px;
+}
+.right-sidebar-panel {
+	border-left: 1px solid var(--sl-color-gray-5);
+}
+@keyframes mirage-fade-up {
+	from {
+		opacity: 0;
+		transform: translateY(18px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+.mirage-reveal {
+	opacity: 0;
+	transform: translateY(18px);
+}
+.mirage-reveal.is-visible {
+	animation: mirage-fade-up 0.7s var(--mirage-ease) forwards;
+}
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*:before,
+	*:after {
+		animation-duration: 0.001ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.001ms !important;
+		scroll-behavior: auto !important;
+	}
+	.mirage-reveal {
+		opacity: 1;
+		transform: none;
+	}
+}
 
-.sl-markdown-content:not(:has(.mirage-landing))>p:has(>img){margin-block:2rem .8rem}
-.sl-markdown-content:not(:has(.mirage-landing))>p>img{width:100%;border-radius:14px;border:1px solid var(--sl-color-gray-5);box-shadow:0 24px 60px rgba(0,0,0,.24)}
-.sl-markdown-content:not(:has(.mirage-landing))>p:has(>em:only-child){margin-top:0;color:var(--sl-color-gray-3);font-size:.82rem;line-height:1.55;text-align:center}
+.sl-markdown-content:not(:has(.mirage-landing)) > p:has(> img) {
+	margin-block: 2rem 0.8rem;
+}
+.sl-markdown-content:not(:has(.mirage-landing)) > p > img {
+	width: 100%;
+	border-radius: 14px;
+	border: 1px solid var(--sl-color-gray-5);
+	box-shadow: 0 24px 60px rgba(0, 0, 0, 0.24);
+}
+.sl-markdown-content:not(:has(.mirage-landing)) > p:has(> em:only-child) {
+	margin-top: 0;
+	color: var(--sl-color-gray-3);
+	font-size: 0.82rem;
+	line-height: 1.55;
+	text-align: center;
+}
 
-.support-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:1rem;margin:2rem 0 2.5rem}
-.support-card{min-width:0;display:flex;flex-direction:column;gap:.35rem;padding:1rem;border:1px solid var(--sl-color-gray-5);border-radius:14px;background:var(--sl-color-gray-6);color:var(--sl-color-white)!important;text-decoration:none!important;box-shadow:0 16px 44px color-mix(in srgb,var(--sl-color-black) 18%,transparent)}
-.support-card img{width:100%;aspect-ratio:1/1;object-fit:contain;border-radius:9px;background:#fff}
-.support-card strong{margin-top:.55rem;font-size:1rem}
-.support-card span{color:var(--sl-color-gray-2);font-size:.78rem;line-height:1.5}
-a.support-card{transition:transform .22s var(--mirage-ease),border-color .22s ease}
-a.support-card:hover{transform:translateY(-3px);border-color:var(--sl-color-accent)}
-@media(max-width:700px){.support-grid{grid-template-columns:1fr;gap:.85rem}.support-card{padding:.85rem}.sl-markdown-content table{display:block;overflow-x:auto}}
+.support-grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 1rem;
+	margin: 2rem 0 2.5rem;
+}
+.support-card {
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.35rem;
+	padding: 1rem;
+	border: 1px solid var(--sl-color-gray-5);
+	border-radius: 14px;
+	background: var(--sl-color-gray-6);
+	color: var(--sl-color-white) !important;
+	text-decoration: none !important;
+	box-shadow: 0 16px 44px
+		color-mix(in srgb, var(--sl-color-black) 18%, transparent);
+}
+.support-card img {
+	width: 100%;
+	aspect-ratio: 1 / 1;
+	object-fit: contain;
+	border-radius: 9px;
+	background: #fff;
+}
+.support-card strong {
+	margin-top: 0.55rem;
+	font-size: 1rem;
+}
+.support-card span {
+	color: var(--sl-color-gray-2);
+	font-size: 0.78rem;
+	line-height: 1.5;
+}
+a.support-card {
+	transition:
+		transform 0.22s var(--mirage-ease),
+		border-color 0.22s ease;
+}
+a.support-card:hover {
+	transform: translateY(-3px);
+	border-color: var(--sl-color-accent);
+}
+@media (max-width: 700px) {
+	.support-grid {
+		grid-template-columns: 1fr;
+		gap: 0.85rem;
+	}
+	.support-card {
+		padding: 0.85rem;
+	}
+	.sl-markdown-content table {
+		display: block;
+		overflow-x: auto;
+	}
+}


### PR DESCRIPTION
## 前言

在 B 站上刷到了这个项目，真是帮大忙了！

想做点什么，可惜我看不懂代码（）只能在 web 上面做一些细小的工作了。

## 修复清单

### 卡片错位

<img width="1387" height="773" alt="image" src="https://github.com/user-attachments/assets/0aeef945-b57c-41bf-a97f-814a53911bfe" />

这第一个卡片底部莫名其妙多了间距，导致顶部不对齐，怎么回事呢？

研究后发现，这是因为首页被 `StarlightPage` 组件包了一层，Starlight 为了让 Markdown 段落之间有间距，内置了这样一条“流式间距”规则（在 `@astrojs/starlight/style/markdown.css` 第 2–6 行）：

```css
.sl-markdown-content
  :not(a, strong, em, del, span, input, code, br)
  + :not(a, strong, em, del, span, input, code, br, :where(.not-content *)) {
  margin-top: var(--sl-content-gap-y);   /* = 1rem = 16px */
}
```

意思是：`.sl-markdown-content` 里任意一个「相邻兄弟元素」的第二个，都会被打上 `margin-top: 16px`。

而这两个 `<article class="paired-card">` 正好是相邻兄弟，所以第二个卡片（“动态屏保”那张）被这条规则额外加了 `margin-top: 16px`，被整体往下顶了 16px，于是两张卡片的顶部就不齐了。给落地页根节点加上 Starlight 官方的「非 Markdown 内容」标记 `not-content`之后，上面的间距规则里 `:where(.not-content *)` 便不再匹配，漏进来的 `margin-top` 就消失了。

### 莫名其妙的横线

其实有一个更加明显的问题，在 header

<img width="981" height="89" alt="image" src="https://github.com/user-attachments/assets/711aec88-5708-4362-86b3-3367d3c2e29a" />

两条线也太丑了吧！谁想出来的直接写样式进入 header 的……好像是 Starlight，我也改不了，只能这样子了：

```css
header {
    border-bottom: 1px solid var(--sl-color-gray-5);
    backdrop-filter: blur(18px);
}

header > .header {
    border-bottom: none;
    backdrop-filter: none;
}
```

### 格式化

所有者居然没有配置格式化嘛，改的时候眼镜都要看花了。我在这个 PR 里面添加了 biome，可以用下面的命令进行检查：

<img width="456" height="326" alt="image" src="https://github.com/user-attachments/assets/5bf31c15-856e-4329-9114-1762f5e7dc46" />

不过检查出来其实还是有很多问题的，只是这次就不包括进来了。

## End

最后感谢开发者的付出，这是我见过在 Mac 上最好的动态壁纸软件！

希望这个项目越来越好❤️